### PR TITLE
fix: bug in order book and pool orders calculation #323

### DIFF
--- a/x/liquidity/amm/match.go
+++ b/x/liquidity/amm/match.go
@@ -272,24 +272,27 @@ func (ob *OrderBook) Match(lastPrice sdk.Dec) (matchPrice sdk.Dec, quoteCoinDiff
 		if buyTickOpenAmt.LTE(sellTickOpenAmt) {
 			if buyTickOpenAmt.IsPositive() {
 				quoteCoinDiff = quoteCoinDiff.Add(DistributeOrderAmountToTick(buyTick, buyTickOpenAmt, matchPrice))
+				matched = true
 			}
 			bi++
 		} else {
 			if sellTickOpenAmt.IsPositive() {
 				quoteCoinDiff = quoteCoinDiff.Add(DistributeOrderAmountToTick(buyTick, sellTickOpenAmt, matchPrice))
+				matched = true
 			}
 		}
 		if sellTickOpenAmt.LTE(buyTickOpenAmt) {
 			if sellTickOpenAmt.IsPositive() {
 				quoteCoinDiff = quoteCoinDiff.Add(DistributeOrderAmountToTick(sellTick, sellTickOpenAmt, matchPrice))
+				matched = true
 			}
 			si++
 		} else {
 			if buyTickOpenAmt.IsPositive() {
 				quoteCoinDiff = quoteCoinDiff.Add(DistributeOrderAmountToTick(sellTick, buyTickOpenAmt, matchPrice))
+				matched = true
 			}
 		}
-		matched = true
 	}
 	return
 }

--- a/x/liquidity/amm/orderbook.go
+++ b/x/liquidity/amm/orderbook.go
@@ -26,11 +26,13 @@ func NewOrderBook(orders ...Order) *OrderBook {
 // AddOrder adds orders to the order book.
 func (ob *OrderBook) AddOrder(orders ...Order) {
 	for _, order := range orders {
-		switch order.GetDirection() {
-		case Buy:
-			ob.buys.addOrder(order)
-		case Sell:
-			ob.sells.addOrder(order)
+		if MatchableAmount(order, order.GetPrice()).IsPositive() {
+			switch order.GetDirection() {
+			case Buy:
+				ob.buys.addOrder(order)
+			case Sell:
+				ob.sells.addOrder(order)
+			}
 		}
 	}
 }

--- a/x/liquidity/amm/pool.go
+++ b/x/liquidity/amm/pool.go
@@ -601,7 +601,10 @@ func PoolBuyOrders(pool Pool, orderer Orderer, lowestPrice, highestPrice sdk.Dec
 		tmpPool.SetBalances(rx, ry)
 	}
 	if poolPrice.GT(highestPrice) {
-		placeOrder(highestPrice, tmpPool.BuyAmountTo(highestPrice))
+		amt := tmpPool.BuyAmountTo(highestPrice)
+		if amt.IsPositive() {
+			placeOrder(highestPrice, tmpPool.BuyAmountTo(highestPrice))
+		}
 	}
 	tick := PriceToDownTick(tmpPool.Price(), tickPrec)
 	for tick.GTE(lowestPrice) {
@@ -639,7 +642,10 @@ func PoolSellOrders(pool Pool, orderer Orderer, lowestPrice, highestPrice sdk.De
 		tmpPool.SetBalances(rx, ry)
 	}
 	if poolPrice.LT(lowestPrice) {
-		placeOrder(lowestPrice, tmpPool.SellAmountTo(lowestPrice))
+		amt := tmpPool.SellAmountTo(lowestPrice)
+		if amt.IsPositive() {
+			placeOrder(lowestPrice, tmpPool.SellAmountTo(lowestPrice))
+		}
 	}
 	tick := PriceToUpTick(tmpPool.Price(), tickPrec)
 	for tick.LTE(highestPrice) {

--- a/x/liquidity/amm/pool_test.go
+++ b/x/liquidity/amm/pool_test.go
@@ -862,7 +862,7 @@ func TestRangedPool_BuyAmountTo(t *testing.T) {
 				utils.ParseDec("0.9"), utils.ParseDec("1.1"),
 			),
 			utils.ParseDec("0.899580000000000000"),
-			sdk.NewInt(1063691),
+			sdk.NewInt(1064187),
 		},
 	} {
 		t.Run("", func(t *testing.T) {

--- a/x/liquidity/keeper/swap_test.go
+++ b/x/liquidity/keeper/swap_test.go
@@ -881,6 +881,34 @@ func (s *KeeperTestSuite) TestSwap_edgecase2() {
 	s.Require().True(decEq(utils.ParseDec("1.6248"), *pair.LastPrice))
 }
 
+func (s *KeeperTestSuite) TestOrderBooks_edgecase1() {
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
+	pair.LastPrice = utils.ParseDecP("0.57472")
+	s.keeper.SetPair(s.ctx, pair)
+
+	s.createPool(s.addr(0), pair.Id, utils.ParseCoins("991883358661denom2,620800303846denom1"), true)
+	s.createRangedPool(
+		s.addr(0), pair.Id, utils.ParseCoins("155025981873denom2,4703143223denom1"),
+		utils.ParseDec("1.15"), utils.ParseDec("1.55"), utils.ParseDec("1.5308"), true)
+	s.createRangedPool(
+		s.addr(0), pair.Id, utils.ParseCoins("223122824634denom2,26528571912denom1"),
+		utils.ParseDec("1.25"), utils.ParseDec("1.45"), utils.ParseDec("1.4199"), true)
+
+	resp, err := s.querier.OrderBooks(sdk.WrapSDKContext(s.ctx), &types.QueryOrderBooksRequest{
+		PairIds:        []uint64{pair.Id},
+		TickPrecisions: []uint32{3},
+		NumTicks:       10,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resp.Pairs, 1)
+	s.Require().Len(resp.Pairs[0].OrderBooks, 1)
+
+	s.Require().Len(resp.Pairs[0].OrderBooks[0].Buys, 1)
+	s.Require().True(decEq(utils.ParseDec("0.6321"), resp.Pairs[0].OrderBooks[0].Buys[0].Price))
+	s.Require().True(intEq(sdk.NewInt(1178846737645), resp.Pairs[0].OrderBooks[0].Buys[0].UserOrderAmount))
+	s.Require().Len(resp.Pairs[0].OrderBooks[0].Sells, 0)
+}
+
 func (s *KeeperTestSuite) TestPoolPreserveK() {
 	r := rand.New(rand.NewSource(0))
 

--- a/x/liquidity/keeper/swap_test.go
+++ b/x/liquidity/keeper/swap_test.go
@@ -835,7 +835,7 @@ func (s *KeeperTestSuite) TestExhaustRangedPool() {
 	fmt.Println(s.getBalances(orderer))
 }
 
-func (s *KeeperTestSuite) TestSwap_EdgeCase() {
+func (s *KeeperTestSuite) TestSwap_edgecase1() {
 	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
 
 	s.sellLimitOrder(s.addr(2), pair.Id, utils.ParseDec("0.102"), sdk.NewInt(10000), 0, true)
@@ -849,6 +849,36 @@ func (s *KeeperTestSuite) TestSwap_EdgeCase() {
 	s.sellLimitOrder(s.addr(3), pair.Id, utils.ParseDec("0.101"), sdk.NewInt(9995), 0, true)
 	s.buyLimitOrder(s.addr(4), pair.Id, utils.ParseDec("0.102"), sdk.NewInt(10000), 0, true)
 	s.nextBlock()
+}
+
+func (s *KeeperTestSuite) TestSwap_edgecase2() {
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
+	pair.LastPrice = utils.ParseDecP("1.6724")
+	s.keeper.SetPair(s.ctx, pair)
+
+	s.createPool(s.addr(0), pair.Id, utils.ParseCoins("1005184935980denom2,601040339855denom1"), true)
+	s.createRangedPool(
+		s.addr(0), pair.Id, utils.ParseCoins("17335058855denom2"),
+		utils.ParseDec("1.15"), utils.ParseDec("1.55"), utils.ParseDec("1.55"), true)
+	s.createRangedPool(
+		s.addr(0), pair.Id, utils.ParseCoins("217771046279denom2"),
+		utils.ParseDec("1.25"), utils.ParseDec("1.45"), utils.ParseDec("1.45"), true)
+
+	s.sellMarketOrder(s.addr(1), pair.Id, sdk.NewInt(4336_000000), 0, true)
+	s.nextBlock()
+
+	pair, _ = s.keeper.GetPair(s.ctx, pair.Id)
+	s.Require().True(decEq(utils.ParseDec("1.6484"), *pair.LastPrice))
+
+	s.nextBlock()
+	pair, _ = s.keeper.GetPair(s.ctx, pair.Id)
+	s.Require().True(decEq(utils.ParseDec("1.6484"), *pair.LastPrice))
+
+	s.sellMarketOrder(s.addr(1), pair.Id, sdk.NewInt(4450_000000), 0, true)
+	s.nextBlock()
+
+	pair, _ = s.keeper.GetPair(s.ctx, pair.Id)
+	s.Require().True(decEq(utils.ParseDec("1.6248"), *pair.LastPrice))
 }
 
 func (s *KeeperTestSuite) TestPoolPreserveK() {


### PR DESCRIPTION
## Description

## Tasks

- [x] Cherry-pick commits from https://github.com/cosmosquad-labs/squad/pull/323
  - do not add order with zero matchable amount to order book
  - check if result of BuyAmountTo/SellAmountUnder is positive
  - set matched to true only when order distribution has happened
  - fix bug in pool order amount calculation(use swap price instead of adjusted price)

## References

- https://github.com/cosmosquad-labs/squad/pull/323

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
