### PR TITLE
fix: limit the number of active pools in a pair #340

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## v2.0.0
+## v2.1.0
 
 ### Client Breaking Changes
 
@@ -69,6 +69,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### State Machine Breaking
 
+* (x/liquidity) [\#49](https://github.com/crescent-network/crescent/pull/49) Add `MaxNumActivePoolsPerPair` global constant
 * (x/liquidity) [\#37](https://github.com/crescent-network/crescent/pull/37) Change `Pool` struct for ranged pools and refactor matching logic
   * Add `type`, `creator`, `min_price` and `max_price` fields to `Pool` struct
   * Refactor matching logic both for fairness of matching and efficiency of pool order placement

--- a/x/liquidity/types/errors.go
+++ b/x/liquidity/types/errors.go
@@ -24,4 +24,5 @@ var (
 	ErrDuplicatePairId           = sdkerrors.Register(ModuleName, 16, "duplicate pair id presents in the pair id list")
 	ErrTooSmallOrder             = sdkerrors.Register(ModuleName, 17, "too small order")
 	ErrTooLargePool              = sdkerrors.Register(ModuleName, 18, "too large pool")
+	ErrTooManyPools              = sdkerrors.Register(ModuleName, 19, "too many pools in the pair")
 )

--- a/x/liquidity/types/params.go
+++ b/x/liquidity/types/params.go
@@ -39,6 +39,10 @@ const (
 	PairEscrowAddressPrefix   = "PairEscrowAddress"
 	ModuleAddressNameSplitter = "|"
 	AddressType               = farmingtypes.AddressType32Bytes
+
+	// MaxNumActivePoolsPerPair is the maximum number of active(not disabled)
+	// pools per pair.
+	MaxNumActivePoolsPerPair = 50
 )
 
 var (


### PR DESCRIPTION
## Description

Add `MaxNumActivePoolsPerPair` global constant.

## Tasks

- [x] Cherry-pick commits from https://github.com/cosmosquad-labs/squad/pull/340

## References

- https://github.com/cosmosquad-labs/squad/pull/340

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
