### PR TITLE
fix: bug some pool coins voting power omitted on voting_powers #342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (x/liquidity) [\#50](https://github.com/crescent-network/crescent/pull/50) Enable detailed configuration for order book responses
 
-## v2.1.0
+### Bug Fixes
+* (x/liquidstaking) [\#51](https://github.com/crescent-network/crescent/pull/51) fix: calculation bug of liquidstaking voting_power gRPC endpoint
+
+## [v2.1.0] - 2022-07-18
 
 ### Client Breaking Changes
 
@@ -133,6 +136,7 @@ Running a full node will encounter wrong app hash issue if it doesn't upgrade to
   * `x/vesting` feat: periodic vesting msg
   * `x/bank` feat: Add dynamic blockedAddrs
   
-[Unreleased]: https://github.com/crescent-network/crescent/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/crescent-network/crescent/compare/v2.1.0...HEAD
 [v1.0.0]: https://github.com/crescent-network/crescent/releases/tag/v1.0.0
 [v1.1.0]: https://github.com/crescent-network/crescent/releases/tag/v1.1.0
+[v2.1.0]: https://github.com/crescent-network/crescent/releases/tag/v2.1.0

--- a/x/liquidstaking/keeper/keeper_test.go
+++ b/x/liquidstaking/keeper/keeper_test.go
@@ -404,3 +404,10 @@ func (s *KeeperTestSuite) Unstake(farmerAcc sdk.AccAddress, amt sdk.Coins) {
 	err := s.app.FarmingKeeper.Unstake(s.ctx, farmerAcc, amt)
 	s.Require().NoError(err)
 }
+
+func (s *KeeperTestSuite) assertVotingPower(addr sdk.AccAddress, stakingVotingPower, liquidStakingVotingPower, validatorVotingPower sdk.Int) {
+	vp := s.keeper.GetVotingPower(s.ctx, addr)
+	s.Require().Equal(stakingVotingPower, vp.StakingVotingPower)
+	s.Require().Equal(liquidStakingVotingPower, vp.LiquidStakingVotingPower)
+	s.Require().Equal(validatorVotingPower, vp.ValidatorVotingPower)
+}

--- a/x/liquidstaking/types/expected_keepers.go
+++ b/x/liquidstaking/types/expected_keepers.go
@@ -104,6 +104,7 @@ type LiquidityKeeper interface {
 	GetPool(ctx sdk.Context, id uint64) (pool liquiditytypes.Pool, found bool)
 	GetPoolBalances(ctx sdk.Context, pool liquiditytypes.Pool) (rx sdk.Coin, ry sdk.Coin)
 	GetPoolCoinSupply(ctx sdk.Context, pool liquiditytypes.Pool) sdk.Int
+	IterateAllPools(ctx sdk.Context, cb func(pool liquiditytypes.Pool) (stop bool, err error)) error
 }
 
 // FarmingKeeper expected farming keeper (noalias)


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixed a bug that missed the calculation of the voting power of the pool coin that was not in the user's balance when calculating the liquid stacking voting power at the /liquidstaking/v1beta1/voting_power/{voter} grpc endpoint

Fixed to create a bTokenSharePerPoolCoinMap for all pool coins before calculating the voting power for user's farming positions

## References

- https://github.com/cosmosquad-labs/squad/pull/342

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
