### PR TITLE
fix: calculation bug of liquidstaking voting_power #346

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (x/liquidstaking) [\#53](https://github.com/crescent-network/crescent/pull/53) fix: calculation bug of liquidstaking voting_power
+
 ## v2.1.1
 
 ### Improvements

--- a/x/liquidstaking/keeper/keeper_test.go
+++ b/x/liquidstaking/keeper/keeper_test.go
@@ -405,6 +405,15 @@ func (s *KeeperTestSuite) Unstake(farmerAcc sdk.AccAddress, amt sdk.Coins) {
 	s.Require().NoError(err)
 }
 
+func (s *KeeperTestSuite) assertTallyResult(yes, no, vito, abstain int64, proposal govtypes.Proposal) {
+	cachedCtx, _ := s.ctx.CacheContext()
+	_, _, result := s.app.GovKeeper.Tally(cachedCtx, proposal)
+	s.Require().Equal(sdk.NewInt(yes), result.Yes)
+	s.Require().Equal(sdk.NewInt(no), result.No)
+	s.Require().Equal(sdk.NewInt(vito), result.NoWithVeto)
+	s.Require().Equal(sdk.NewInt(abstain), result.Abstain)
+}
+
 func (s *KeeperTestSuite) assertVotingPower(addr sdk.AccAddress, stakingVotingPower, liquidStakingVotingPower, validatorVotingPower sdk.Int) {
 	vp := s.keeper.GetVotingPower(s.ctx, addr)
 	s.Require().Equal(stakingVotingPower, vp.StakingVotingPower)

--- a/x/liquidstaking/keeper/tally.go
+++ b/x/liquidstaking/keeper/tally.go
@@ -181,7 +181,7 @@ func (k Keeper) CalcLiquidStakingVotingPower(ctx sdk.Context, addr sdk.AccAddres
 		}
 
 		// check if the denom is pool coin
-		if bTokenSharePerPoolCoin, ok := bTokenSharePerPoolCoinMap[coin.Denom]; ok && bTokenSharePerPoolCoin.IsPositive() {
+		if bTokenSharePerPoolCoin, ok := bTokenSharePerPoolCoinMap[coin.Denom]; ok {
 			bTokenAmount = bTokenAmount.Add(utils.GetShareValue(coin.Amount, bTokenSharePerPoolCoin))
 		}
 	}
@@ -220,7 +220,7 @@ func (k Keeper) SetLiquidStakingVotingPowers(ctx sdk.Context, votes govtypes.Vot
 
 	// get the map of balance amount of voter by denom
 	voterBalanceByDenom := k.GetVoterBalanceByDenom(ctx, votes)
-	bTokenSharePerPoolCoinMap := map[string]sdk.Dec{}
+	bTokenSharePerPoolCoinMap := k.GetBTokenSharePerPoolCoinMap(ctx, liquidBondDenom)
 	bTokenOwnMap := make(utils.StrIntMap)
 
 	// sort denom keys of voterBalanceByDenom for deterministic iteration
@@ -241,10 +241,8 @@ func (k Keeper) SetLiquidStakingVotingPowers(ctx sdk.Context, votes govtypes.Vot
 			continue
 		}
 
-		// if the denom is pool coin, calc btoken share and add owned btoken on bTokenOwnMap
-		bTokenSharePerPoolCoin := k.TokenSharePerPoolCoin(ctx, liquidBondDenom, denom)
-		if bTokenSharePerPoolCoin.IsPositive() {
-			bTokenSharePerPoolCoinMap[denom] = bTokenSharePerPoolCoin
+		// if the denom is pool coin, get bToken share and add owned bToken on bTokenOwnMap
+		if bTokenSharePerPoolCoin, ok := bTokenSharePerPoolCoinMap[denom]; ok {
 			for voter, balance := range voterBalanceByDenom[denom] {
 				bTokenOwnMap.AddOrSet(voter, utils.GetShareValue(balance, bTokenSharePerPoolCoin))
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixed a bug that missed the calculation of the voting power of the pool coin that was not in the user's balance when calculating the liquid stacking voting power at `SetLiquidStakingVotingPowers`

Fixed to create a `bTokenSharePerPoolCoinMap` for all pool coins before calculating the voting power for user's farming positions

## References

- https://github.com/cosmosquad-labs/squad/pull/346

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
