### PR TITLE
fix: reject same base/quote coin denom in `MsgCreatePair` #365

### DIFF
--- a/x/liquidity/client/cli/query.go
+++ b/x/liquidity/client/cli/query.go
@@ -657,7 +657,7 @@ $ %s query %s order 1 1
 func NewQueryOrderBooksCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "order-books [pair-ids]",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(1),
 		Short: "Query order books",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Query order books of specified pairs.

--- a/x/liquidity/types/msgs.go
+++ b/x/liquidity/types/msgs.go
@@ -61,6 +61,9 @@ func (msg MsgCreatePair) ValidateBasic() error {
 	if err := sdk.ValidateDenom(msg.QuoteCoinDenom); err != nil {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
+	if msg.BaseCoinDenom == msg.QuoteCoinDenom {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "cannot use same denom for both base coin and quote coin")
+	}
 	return nil
 }
 

--- a/x/liquidity/types/msgs_test.go
+++ b/x/liquidity/types/msgs_test.go
@@ -45,6 +45,13 @@ func TestMsgCreatePair(t *testing.T) {
 			},
 			"invalid denom: invaliddenom!: invalid request",
 		},
+		{
+			"same denom",
+			func(msg *types.MsgCreatePair) {
+				msg.QuoteCoinDenom = "denom1"
+			},
+			"cannot use same denom for both base coin and quote coin: invalid request",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			msg := types.NewMsgCreatePair(testAddr, "denom1", "denom2")


### PR DESCRIPTION
## Description

This PR fixes two bugs in the liquidity module.

## Tasks

- [x] Cherry-pick commits from https://github.com/cosmosquad-labs/squad/pull/365

## References

- https://github.com/cosmosquad-labs/squad/pull/365
- https://github.com/cosmosquad-labs/squad/issues/363

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
