### PR TITLE
fix: set previous share to nil for excluded pools

### DIFF
--- a/x/lpfarm/keeper/plan.go
+++ b/x/lpfarm/keeper/plan.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"sort"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -198,8 +197,6 @@ func (k Keeper) AllocateRewards(ctx sdk.Context) error {
 	})
 
 	rewardsByDenom := map[string]sdk.DecCoins{}
-	// We keep this slice for deterministic iteration over the rewardsByDenom map.
-	var denomsWithRewards []string
 	for _, farmingPoolAddr := range ra.farmingPoolAddrs {
 		farmingPool := farmingPoolAddr.String()
 		totalRewards := ra.totalRewardsByFarmingPool[farmingPool]
@@ -212,28 +209,28 @@ func (k Keeper) AllocateRewards(ctx sdk.Context) error {
 			return err
 		}
 		for denom, rewards := range ra.allocatedRewards[farmingPool] {
-			if _, ok := rewardsByDenom[denom]; !ok {
-				denomsWithRewards = append(denomsWithRewards, denom)
-			}
 			rewardsByDenom[denom] = rewardsByDenom[denom].Add(rewards...)
 		}
 	}
 
-	sort.Strings(denomsWithRewards)
-	for _, denom := range denomsWithRewards {
-		farm, found := ck.getFarm(ctx, denom)
-		if !found { // Sanity check
-			panic("farm not found")
-		}
-		farm.CurrentRewards = farm.CurrentRewards.Add(rewardsByDenom[denom]...)
-		farm.OutstandingRewards = farm.OutstandingRewards.Add(rewardsByDenom[denom]...)
-		if pi, ok := ra.poolInfoByPoolCoinDenom[denom]; ok {
-			farm.PreviousShare = &pi.rewardsShare
+	k.IterateAllFarms(ctx, func(denom string, farm types.Farm) (stop bool) {
+		if _, ok := rewardsByDenom[denom]; ok {
+			farm.CurrentRewards = farm.CurrentRewards.Add(rewardsByDenom[denom]...)
+			farm.OutstandingRewards = farm.OutstandingRewards.Add(rewardsByDenom[denom]...)
+			if pi, ok := ra.poolInfoByPoolCoinDenom[denom]; ok {
+				farm.PreviousShare = &pi.rewardsShare
+			} else {
+				farm.PreviousShare = nil
+			}
+			k.SetFarm(ctx, denom, farm)
 		} else {
-			farm.PreviousShare = nil
+			if farm.PreviousShare != nil {
+				farm.PreviousShare = nil
+				k.SetFarm(ctx, denom, farm)
+			}
 		}
-		k.SetFarm(ctx, denom, farm)
-	}
+		return false
+	})
 
 	return nil
 }


### PR DESCRIPTION
## Description

This PR fixes a bug when recording previous share, which was not setting previous share to nil when pools are excluded from the rewards allocation.

## Tasks

- [x] Fix the bug
- [x] Write tests

## References

- 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/v0.45.9/docs/building-modules/README.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
