### PR TITLE
feat: add `NumMMOrdersInvariant` invariant check

### DIFF
--- a/x/liquidity/keeper/invariants.go
+++ b/x/liquidity/keeper/invariants.go
@@ -14,6 +14,7 @@ func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
 	ir.RegisterRoute(types.ModuleName, "pool-coin-escrow", PoolCoinEscrowInvariant(k))
 	ir.RegisterRoute(types.ModuleName, "remaining-offer-coin-escrow", RemainingOfferCoinEscrowInvariant(k))
 	ir.RegisterRoute(types.ModuleName, "pool-status", PoolStatusInvariant(k))
+	ir.RegisterRoute(types.ModuleName, "num-mm-orders", NumMMOrdersInvariant(k))
 }
 
 // AllInvariants returns a combined invariant of the liquidity module.
@@ -24,6 +25,7 @@ func AllInvariants(k Keeper) sdk.Invariant {
 			PoolCoinEscrowInvariant,
 			RemainingOfferCoinEscrowInvariant,
 			PoolStatusInvariant,
+			NumMMOrdersInvariant,
 		} {
 			res, stop := inv(k)(ctx)
 			if stop {
@@ -129,6 +131,55 @@ func PoolStatusInvariant(k Keeper) sdk.Invariant {
 		broken := count != 0
 		return sdk.FormatInvariant(
 			types.ModuleName, "pool-status",
+			fmt.Sprintf("%d pool(s) with wrong status found\n%s", count, msg),
+		), broken
+	}
+}
+
+// NumMMOrdersInvariant checks the actual number of mm orders with NumMMOrders
+// records.
+func NumMMOrdersInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		// orderer address => (pair id => num mm orders)
+		numMMOrdersMap := map[string]map[uint64]uint32{}
+		_ = k.IterateAllOrders(ctx, func(order types.Order) (stop bool, err error) {
+			if order.Type == types.OrderTypeMM {
+				numMMOrdersByPairId, ok := numMMOrdersMap[order.Orderer]
+				if !ok {
+					numMMOrdersByPairId = map[uint64]uint32{}
+					numMMOrdersMap[order.Orderer] = numMMOrdersByPairId
+				}
+				numMMOrdersByPairId[order.PairId]++
+			}
+			return false, nil
+		})
+		var (
+			count int
+			msg   string
+		)
+		k.IterateAllNumMMOrders(ctx, func(ordererAddr sdk.AccAddress, pairId uint64, numMMOrders uint32) (stop bool) {
+			orderer := ordererAddr.String()
+			numMMOrdersByPairId, ok := numMMOrdersMap[orderer]
+			if !ok {
+				count++
+				msg += fmt.Sprintf("\torderer %s has no mm orders\n", orderer)
+				return false
+			}
+			correctNumMMOrders, ok := numMMOrdersByPairId[pairId]
+			if !ok {
+				count++
+				msg += fmt.Sprintf("\torderer %s has no mm orders in pair %d\n", orderer, pairId)
+				return false
+			}
+			if numMMOrders != correctNumMMOrders {
+				count++
+				msg += fmt.Sprintf("\torderer %s has wrong number of mm orders in pair %d; got %d, expected %d\n", orderer, pairId, numMMOrders, correctNumMMOrders)
+			}
+			return false
+		})
+		broken := count != 0
+		return sdk.FormatInvariant(
+			types.ModuleName, "num-mm-orders",
 			fmt.Sprintf("%d pool(s) with wrong status found\n%s", count, msg),
 		), broken
 	}

--- a/x/liquidity/keeper/invariants.go
+++ b/x/liquidity/keeper/invariants.go
@@ -143,7 +143,7 @@ func NumMMOrdersInvariant(k Keeper) sdk.Invariant {
 		// orderer address => (pair id => num mm orders)
 		numMMOrdersMap := map[string]map[uint64]uint32{}
 		_ = k.IterateAllOrders(ctx, func(order types.Order) (stop bool, err error) {
-			if order.Type == types.OrderTypeMM {
+			if order.Type == types.OrderTypeMM && !order.Status.ShouldBeDeleted() {
 				numMMOrdersByPairId, ok := numMMOrdersMap[order.Orderer]
 				if !ok {
 					numMMOrdersByPairId = map[uint64]uint32{}
@@ -180,7 +180,7 @@ func NumMMOrdersInvariant(k Keeper) sdk.Invariant {
 		broken := count != 0
 		return sdk.FormatInvariant(
 			types.ModuleName, "num-mm-orders",
-			fmt.Sprintf("%d pool(s) with wrong status found\n%s", count, msg),
+			fmt.Sprintf("%d orderer-pair pairs with wrong status\n%s", count, msg),
 		), broken
 	}
 }

--- a/x/liquidity/keeper/invariants_test.go
+++ b/x/liquidity/keeper/invariants_test.go
@@ -89,3 +89,7 @@ func (s *KeeperTestSuite) TestPoolStatusInvariant() {
 	_, broken = keeper.PoolStatusInvariant(s.keeper)(s.ctx)
 	s.Require().True(broken)
 }
+
+func (s *KeeperTestSuite) TestNumMMOrdersInvariant() {
+	// TODO: not implemented
+}

--- a/x/liquidity/keeper/invariants_test.go
+++ b/x/liquidity/keeper/invariants_test.go
@@ -1,8 +1,13 @@
 package keeper_test
 
 import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	utils "github.com/crescent-network/crescent/v5/types"
 	"github.com/crescent-network/crescent/v5/x/liquidity/keeper"
+	"github.com/crescent-network/crescent/v5/x/liquidity/types"
 )
 
 func (s *KeeperTestSuite) TestDepositCoinsEscrowInvariant() {
@@ -91,5 +96,51 @@ func (s *KeeperTestSuite) TestPoolStatusInvariant() {
 }
 
 func (s *KeeperTestSuite) TestNumMMOrdersInvariant() {
-	// TODO: not implemented
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
+
+	orderer := s.addr(1)
+	// Place random MM orders
+	s.mmOrder(
+		orderer, pair.Id, types.OrderDirectionBuy,
+		utils.ParseDec("0.99"), sdk.NewInt(1000000), time.Hour, true)
+	s.mmOrder(
+		orderer, pair.Id, types.OrderDirectionBuy,
+		utils.ParseDec("0.98"), sdk.NewInt(1000000), time.Hour, true)
+	s.mmOrder(
+		orderer, pair.Id, types.OrderDirectionBuy,
+		utils.ParseDec("0.97"), sdk.NewInt(1000000), time.Hour, true)
+	s.mmOrder(
+		orderer, pair.Id, types.OrderDirectionSell,
+		utils.ParseDec("1.01"), sdk.NewInt(1000000), time.Hour, true)
+	s.mmOrder(
+		orderer, pair.Id, types.OrderDirectionSell,
+		utils.ParseDec("1.02"), sdk.NewInt(1000000), time.Hour, true)
+	s.mmOrder(
+		orderer, pair.Id, types.OrderDirectionSell,
+		utils.ParseDec("1.03"), sdk.NewInt(1000000), time.Hour, true)
+
+	_, broken := keeper.NumMMOrdersInvariant(s.keeper)(s.ctx)
+	s.Require().False(broken)
+
+	s.nextBlock()
+
+	// Cancel some MM orders and place another order
+	s.cancelOrder(orderer, pair.Id, 1)
+	s.cancelOrder(orderer, pair.Id, 2)
+	s.mmOrder(
+		orderer, pair.Id, types.OrderDirectionSell,
+		utils.ParseDec("1.04"), sdk.NewInt(1000000), time.Hour, true)
+
+	_, broken = keeper.NumMMOrdersInvariant(s.keeper)(s.ctx)
+	s.Require().False(broken)
+
+	// After deleting canceled orders, the invariant must not be broken
+	s.nextBlock()
+	_, broken = keeper.NumMMOrdersInvariant(s.keeper)(s.ctx)
+	s.Require().False(broken)
+
+	// Break it
+	s.keeper.SetNumMMOrders(s.ctx, orderer, pair.Id, 3)
+	_, broken = keeper.NumMMOrdersInvariant(s.keeper)(s.ctx)
+	s.Require().True(broken)
 }

--- a/x/liquidity/module.go
+++ b/x/liquidity/module.go
@@ -153,7 +153,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 }
 
 // RegisterInvariants registers the capability module's invariants.
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+	keeper.RegisterInvariants(ir, am.keeper)
+}
 
 // InitGenesis performs the capability module's genesis initialization It returns
 // no validator updates.


### PR DESCRIPTION
## Description

This PR adds an `x/liquidity` invariant check for the recently added `NumMMOrders` state.

## Tasks

- [x] Add `NumMMOrdersInvariant`
- [x] Write invariant test

## References

- 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/v0.45.9/docs/building-modules/README.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
