### PR TITLE
fix: Change total rewards to truncate dec for each validator.

### DIFF
--- a/x/liquidstaking/keeper/liquidstaking.go
+++ b/x/liquidstaking/keeper/liquidstaking.go
@@ -281,7 +281,7 @@ func (k Keeper) CheckDelegationStates(ctx sdk.Context, proxyAcc sdk.AccAddress) 
 				totalDelShares = totalDelShares.Add(delShares)
 				liquidTokens := val.TokensFromSharesTruncated(delShares).TruncateInt()
 				totalLiquidTokens = totalLiquidTokens.Add(liquidTokens)
-				totalRewards = totalRewards.Add(delReward.AmountOf(bondDenom))
+				totalRewards = totalRewards.Add(delReward.AmountOf(bondDenom).TruncateDec())
 			}
 			return false
 		},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

currently nas.TotalRemainingRewards are calculated as summation of each rewards and then Truncated.

But while claiming rewards each validator rewards gets truncated. 
Hence the tests only work with specific inflation/ target-weights,etc.
example [rebalancing_test.go line 475](https://github.com/crescent-network/crescent/blob/main/x/liquidstaking/keeper/rebalancing_test.go#L475)- if you were to just change 
 		`{ValidatorAddress: valOpers[0].String(), TargetWeight: sdk.NewInt(10)},`
To 
		`{ValidatorAddress: valOpers[0].String(), TargetWeight: sdk.NewInt(100)},`

- the test case fails.. 

Solution is one of two - truncate decs or... remove the assertion of rewards checking in tests.


I was trying to fork liquid staking and repurpose it without tally/ liquidity/ farming 
closes: #XXXX

## Tasks

- [ ] 

## References

- 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/v0.45.9/docs/building-modules/README.md).
- [x] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
