### PR TITLE
build!: bump cosmos-sdk to v1.1.5-sdk-0.45.10 for barberry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [v4.2.0] - 2023-06-09
+
+### State Machine Breaking
+
+- (deps) [\#157](https://github.com/crescent-network/crescent/pull/157) build!: bump cosmos-sdk to v1.1.5-sdk-0.45.10 for barberry
+
 ## [v4.1.1] - 2023-05-26
 
 - (ibc) [\#155](https://github.com/crescent-network/crescent/pull/155) build: bump ibc-go to v3.4.0-crescent-v4-3 for huckleberry
@@ -206,3 +212,4 @@ Running a full node will encounter wrong app hash issue if it doesn't upgrade to
 [v4.0.0]: https://github.com/crescent-network/crescent/releases/tag/v4.0.0
 [v4.1.0]: https://github.com/crescent-network/crescent/releases/tag/v4.1.0
 [v4.1.1]: https://github.com/crescent-network/crescent/releases/tag/v4.1.1
+[v4.2.0]: https://github.com/crescent-network/crescent/releases/tag/v4.2.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Use `git` to retrieve Crescent Core from [the official repository](https://githu
 
 ```bash
 git clone https://github.com/crescent-network/crescent.git
-cd crescent && git checkout release/v4.0.x
+cd crescent && git checkout release/v4.2.x
 make install
 ```
 
@@ -65,7 +65,7 @@ Crescent core uses a fork of [cosmos-sdk](https://github.com/crescent-network/co
 
 | Requirement         | Notes                |
 |---------------------|----------------------|
-| cosmos-sdk (forked) | v1.1.4-sdk-0.45.10   |
+| cosmos-sdk (forked) | v1.1.5-sdk-0.45.10   |
 | ibc-go (forked)     | v3.4.0-crescent-v4-3 |
 
 ## Documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Privately and confidentially send us a description of the vulnerability that you have discovered. Our contact information is given below.
+
+In your report, please include as much information as you can, including:
+
+* a description of the vulnerability and how it could be exploited
+* its potential impact (e.g. theft of funds, denial of service)
+* steps or code for reproducing it
+* a proposed patch for remedying it
+
+## How to Contact Us
+
+crypin@crescent.foundation
+king@crescent.foundation

--- a/go.mod
+++ b/go.mod
@@ -261,7 +261,7 @@ require (
 
 replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0 // dragonberry security patch
-	github.com/cosmos/cosmos-sdk => github.com/crescent-network/cosmos-sdk v1.1.4-sdk-0.45.10
+	github.com/cosmos/cosmos-sdk => github.com/crescent-network/cosmos-sdk v1.1.5-sdk-0.45.10 // barberry security patch, customized
 	github.com/cosmos/ibc-go/v3 => github.com/crescent-network/ibc-go/v3 v3.4.0-crescent-v4-3 // huckleberry security patch
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	// github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/creachadair/taskgroup v0.3.2 h1:zlfutDS+5XG40AOxcHDSThxKzns8Tnr9jnr6V
 github.com/creachadair/taskgroup v0.3.2/go.mod h1:wieWwecHVzsidg2CsUnFinW1faVN4+kq+TDlRJQ0Wbk=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crescent-network/cosmos-sdk v1.1.4-sdk-0.45.10 h1:JBdGVt8oGb15r/hi9xmTGwcUnJdf0mjzvAHTN6ykFRI=
-github.com/crescent-network/cosmos-sdk v1.1.4-sdk-0.45.10/go.mod h1:CbfWNs4PuxxsvRD/snQuSBDwIhtsD7rIDTVQyYMKTa0=
+github.com/crescent-network/cosmos-sdk v1.1.5-sdk-0.45.10 h1:jf8mc04DO8EVBIfQUAtz43Owfg8uJDv/WYcPnOOG7Uo=
+github.com/crescent-network/cosmos-sdk v1.1.5-sdk-0.45.10/go.mod h1:CbfWNs4PuxxsvRD/snQuSBDwIhtsD7rIDTVQyYMKTa0=
 github.com/crescent-network/ibc-go/v3 v3.4.0-crescent-v4-3 h1:eBQwupfSDLTDmjFuUefWFel//BCWMPEPouWWWoANLNI=
 github.com/crescent-network/ibc-go/v3 v3.4.0-crescent-v4-3/go.mod h1:tR2qrfrmeZqKiZh2tlTotpq3FDaXLD4omi3sBpaq21w=
 github.com/cristalhq/acmd v0.8.1/go.mod h1:LG5oa43pE/BbxtfMoImHCQN++0Su7dzipdgBjMCBVDQ=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Bump cosmos-sdk to [v1.1.5-sdk-0.45.10](https://github.com/crescent-network/cosmos-sdk/releases/tag/v1.1.5-sdk-0.45.10) for Barberry security patch

### Fix Barberry Vesting Bug and Infinite Feegrant Bug
- [Cosmos SDK Security Advisory Barberry](https://forum.cosmos.network/t/cosmos-sdk-security-advisory-barberry/10825) (backport from https://github.com/cosmos/cosmos-sdk/pull/16466 of [v0.46.13](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.13))
- Infinite Feegrant Bug (backport from https://github.com/cosmos/cosmos-sdk/pull/16097 of [v0.45.16](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.45.16))
