### PR TITLE
fix: fix bug in placeLimitOrder and exchange invariant checks

### DIFF
--- a/x/exchange/keeper/order.go
+++ b/x/exchange/keeper/order.go
@@ -155,11 +155,15 @@ func (k Keeper) placeLimitOrder(
 		}
 	}
 
-	if isBatch || qty.Sub(res.ExecutedQuantity).IsPositive() {
+	openQty := qty
+	if !isBatch {
+		openQty = openQty.Sub(res.ExecutedQuantity)
+	}
+	if isBatch || openQty.IsPositive() {
 		deadline := ctx.BlockTime().Add(lifespan)
 		order, err = k.newOrder(
 			ctx, orderId, typ, market, ordererAddr, isBuy, price,
-			qty, qty.Sub(res.ExecutedQuantity), deadline, false)
+			qty, openQty, deadline, false)
 		if err != nil {
 			return
 		}

--- a/x/exchange/keeper/order_test.go
+++ b/x/exchange/keeper/order_test.go
@@ -97,8 +97,8 @@ func (s *KeeperTestSuite) TestPlaceBatchLimitOrder() {
 }
 
 func (s *KeeperTestSuite) TestOrderMatching() {
-	aliceAddr := s.FundedAccount(1, enoughCoins)
-	bobAddr := s.FundedAccount(2, enoughCoins)
+	aliceAddr := s.FundedAccount(1, utils.ParseCoins("1000000ucre,1000000uusd"))
+	bobAddr := s.FundedAccount(2, utils.ParseCoins("1000000ucre,1000000uusd"))
 
 	market := s.CreateMarket(utils.TestAddress(3), "ucre", "uusd", true)
 

--- a/x/exchange/keeper/order_test.go
+++ b/x/exchange/keeper/order_test.go
@@ -6,14 +6,99 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	utils "github.com/crescent-network/crescent/v5/types"
+	"github.com/crescent-network/crescent/v5/x/exchange/keeper"
+	"github.com/crescent-network/crescent/v5/x/exchange/types"
 )
 
-func (s *KeeperTestSuite) TestOrderMatching() {
-	aliceAddr := utils.TestAddress(1)
-	bobAddr := utils.TestAddress(2)
+func (s *KeeperTestSuite) TestPlaceLimitOrder() {
+	market := s.CreateMarket(utils.TestAddress(0), "ucre", "uusd", true)
 
-	s.FundAccount(aliceAddr, utils.ParseCoins("1000000ucre,1000000uusd"))
-	s.FundAccount(bobAddr, utils.ParseCoins("1000000ucre,1000000uusd"))
+	ordererAddr1 := s.FundedAccount(1, enoughCoins)
+	ordererAddr2 := s.FundedAccount(2, enoughCoins)
+
+	msgServer := keeper.NewMsgServerImpl(s.keeper)
+	s.Ctx = s.Ctx.WithEventManager(sdk.NewEventManager())
+	resp, err := msgServer.PlaceLimitOrder(
+		sdk.WrapSDKContext(s.Ctx), types.NewMsgPlaceLimitOrder(
+			ordererAddr1, market.Id, true, utils.ParseDec("5.1"), sdk.NewInt(10_000000), time.Hour))
+	s.Require().NoError(err)
+	s.Require().EqualValues(1, resp.OrderId)
+	s.Require().Equal(sdk.NewInt(0), resp.ExecutedQuantity)
+	s.Require().Equal(sdk.NewInt64Coin("uusd", 0), resp.Paid)
+	s.Require().Equal(sdk.NewInt64Coin("ucre", 0), resp.Received)
+	s.CheckEvent(&types.EventPlaceLimitOrder{}, map[string][]byte{
+		"executed_quantity": []byte(`"0"`),
+		"paid":              []byte(`{"denom":"uusd","amount":"0"}`),
+		"received":          []byte(`{"denom":"ucre","amount":"0"}`),
+	})
+
+	s.Ctx = s.Ctx.WithEventManager(sdk.NewEventManager())
+	resp, err = msgServer.PlaceLimitOrder(
+		sdk.WrapSDKContext(s.Ctx), types.NewMsgPlaceLimitOrder(
+			ordererAddr2, market.Id, false, utils.ParseDec("5"), sdk.NewInt(5_000000), time.Hour))
+	s.Require().NoError(err)
+	s.Require().EqualValues(2, resp.OrderId)
+	s.Require().Equal(sdk.NewInt(5_000000), resp.ExecutedQuantity)
+	s.Require().Equal(sdk.NewInt64Coin("ucre", 5_000000), resp.Paid)
+	// Matched at 5.1
+	s.Require().Equal(sdk.NewInt64Coin("uusd", 25_423500), resp.Received)
+	s.CheckEvent(&types.EventPlaceLimitOrder{}, map[string][]byte{
+		"executed_quantity": []byte(`"5000000"`),
+		"paid":              []byte(`{"denom":"ucre","amount":"5000000"}`),
+		"received":          []byte(`{"denom":"uusd","amount":"25423500"}`),
+	})
+}
+
+func (s *KeeperTestSuite) TestPlaceBatchLimitOrder() {
+	market := s.CreateMarket(utils.TestAddress(0), "ucre", "uusd", true)
+
+	ordererAddr1 := s.FundedAccount(1, enoughCoins)
+	ordererAddr2 := s.FundedAccount(2, enoughCoins)
+
+	ordererBalances1Before := s.GetAllBalances(ordererAddr1)
+	ordererBalances2Before := s.GetAllBalances(ordererAddr2)
+	s.PlaceBatchLimitOrder(
+		market.Id, ordererAddr1, true, utils.ParseDec("5.1"), sdk.NewInt(10_000000), 0)
+	s.PlaceBatchLimitOrder(
+		market.Id, ordererAddr2, false, utils.ParseDec("5"), sdk.NewInt(10_000000), 0)
+	s.Require().NoError(s.keeper.RunBatchMatching(s.Ctx, market))
+	s.NextBlock()
+
+	marketState := s.keeper.MustGetMarketState(s.Ctx, market.Id)
+	s.Require().NotNil(marketState.LastPrice)
+	s.Require().Equal("5.050000000000000000", marketState.LastPrice.String())
+	ordererBalances1After := s.GetAllBalances(ordererAddr1)
+	ordererBalances2After := s.GetAllBalances(ordererAddr2)
+	ordererBalances1Diff, _ := ordererBalances1After.SafeSub(ordererBalances1Before)
+	ordererBalances2Diff, _ := ordererBalances2After.SafeSub(ordererBalances2Before)
+	// Both taker
+	s.Require().Equal("9970000ucre,-50500000uusd", ordererBalances1Diff.String())
+	s.Require().Equal("-10000000ucre,50348500uusd", ordererBalances2Diff.String())
+
+	ordererBalances1Before = ordererBalances1After
+	ordererBalances2Before = ordererBalances2After
+	s.PlaceBatchLimitOrder(
+		market.Id, ordererAddr1, true, utils.ParseDec("5.2"), sdk.NewInt(10_000000), 0)
+	s.PlaceBatchLimitOrder(
+		market.Id, ordererAddr2, false, utils.ParseDec("5.07"), sdk.NewInt(10_000000), 0)
+	s.Require().NoError(s.keeper.RunBatchMatching(s.Ctx, market))
+	s.NextBlock()
+
+	marketState = s.keeper.MustGetMarketState(s.Ctx, market.Id)
+	s.Require().NotNil(marketState.LastPrice)
+	s.Require().Equal("5.070000000000000000", marketState.LastPrice.String())
+	ordererBalances1After = s.GetAllBalances(ordererAddr1)
+	ordererBalances2After = s.GetAllBalances(ordererAddr2)
+	ordererBalances1Diff, _ = ordererBalances1After.SafeSub(ordererBalances1Before)
+	ordererBalances2Diff, _ = ordererBalances2After.SafeSub(ordererBalances2Before)
+	s.Require().Equal("9970000ucre,-50700000uusd", ordererBalances1Diff.String())
+	// Maker
+	s.Require().Equal("-9985000ucre,50700000uusd", ordererBalances2Diff.String())
+}
+
+func (s *KeeperTestSuite) TestOrderMatching() {
+	aliceAddr := s.FundedAccount(1, enoughCoins)
+	bobAddr := s.FundedAccount(2, enoughCoins)
 
 	market := s.CreateMarket(utils.TestAddress(3), "ucre", "uusd", true)
 


### PR DESCRIPTION
## Description

https://github.com/crescent-network/crescent/blob/92ee8b8cf0eced61969f214dd3d72497a0b72091/x/exchange/keeper/order.go#L150-L162

The bug was because we're trying to use `res.ExecutedQuantity` when `isBatch` is true. `res` was not set when `isBatch`.

## Tasks

- [x] Fix bug in `placeLimitOrder`
- [x] Fix x/exchange invariant checks