### PR TITLE
fix: fix bug in NumMMOrders calculation

### DIFF
--- a/x/exchange/keeper/order.go
+++ b/x/exchange/keeper/order.go
@@ -177,8 +177,8 @@ func (k Keeper) placeLimitOrder(
 		k.SetOrdersByOrdererIndex(ctx, order)
 
 		if typ == types.OrderTypeMM {
-			// NOTE: NumMMOrders might have been changed in executeOrder the orderer
-			// completed own orders.
+			// NOTE: NumMMOrders might have been changed in executeOrder if the
+			// orderer completed own orders.
 			numMMOrders, _ = k.GetNumMMOrders(ctx, ordererAddr, marketId)
 			k.SetNumMMOrders(ctx, ordererAddr, marketId, numMMOrders+1)
 		}

--- a/x/exchange/keeper/order.go
+++ b/x/exchange/keeper/order.go
@@ -177,6 +177,9 @@ func (k Keeper) placeLimitOrder(
 		k.SetOrdersByOrdererIndex(ctx, order)
 
 		if typ == types.OrderTypeMM {
+			// NOTE: NumMMOrders might have been changed in executeOrder the orderer
+			// completed own orders.
+			numMMOrders, _ = k.GetNumMMOrders(ctx, ordererAddr, marketId)
 			k.SetNumMMOrders(ctx, ordererAddr, marketId, numMMOrders+1)
 		}
 	}

--- a/x/exchange/keeper/order_test.go
+++ b/x/exchange/keeper/order_test.go
@@ -307,8 +307,6 @@ func (s *KeeperTestSuite) TestDecQuantity() {
 }
 
 func (s *KeeperTestSuite) TestNumMMOrdersEdgecase() {
-	s.keeper.SetMaxNumMMOrders(s.Ctx, 3) // Override the default
-
 	market := s.CreateMarket("ucre", "uusd")
 
 	ordererAddr := s.FundedAccount(1, enoughCoins)

--- a/x/exchange/keeper/order_test.go
+++ b/x/exchange/keeper/order_test.go
@@ -305,3 +305,22 @@ func (s *KeeperTestSuite) TestDecQuantity() {
 	diff, _ := orderer3BalancesAfter.SafeSub(orderer3BalancesBefore)
 	s.AssertEqual(sdk.NewInt(380), diff.AmountOf("uusd")) // 2699.7*0.14076=380.009722
 }
+
+func (s *KeeperTestSuite) TestNumMMOrdersEdgecase() {
+	s.keeper.SetMaxNumMMOrders(s.Ctx, 3) // Override the default
+
+	market := s.CreateMarket("ucre", "uusd")
+
+	ordererAddr := s.FundedAccount(1, enoughCoins)
+	// Place 2 MM orders
+	s.PlaceMMLimitOrder(market.Id, ordererAddr, true, utils.ParseDec("4.9"), sdk.NewDec(10_000000), time.Hour)
+	s.PlaceMMLimitOrder(market.Id, ordererAddr, true, utils.ParseDec("4.85"), sdk.NewDec(10_000000), time.Hour)
+
+	// Match against own orders
+	s.PlaceMMLimitOrder(market.Id, ordererAddr, false, utils.ParseDec("4.5"), sdk.NewDec(30_000000), time.Hour)
+
+	numMMOrders, _ := s.keeper.GetNumMMOrders(s.Ctx, ordererAddr, market.Id)
+	// The number of MM orders should be 1, since previous order are fully matched
+	// and deleted.
+	s.Require().Equal(uint32(1), numMMOrders)
+}


### PR DESCRIPTION
## Description

This PR fixes a bug in `NumMMOrders` calculation. The bug occurs when an orderer places an MM order while matching against own MM orders.
