### PR TITLE
fix: add liquidamm module to v5 store upgrades

### DIFF
--- a/app/upgrades/mainnet/v5/upgrade.go
+++ b/app/upgrades/mainnet/v5/upgrade.go
@@ -23,6 +23,7 @@ import (
 	exchangetypes "github.com/crescent-network/crescent/v5/x/exchange/types"
 	farmingkeeper "github.com/crescent-network/crescent/v5/x/farming/keeper"
 	farmingtypes "github.com/crescent-network/crescent/v5/x/farming/types"
+	liquidammtypes "github.com/crescent-network/crescent/v5/x/liquidamm/types"
 	liquiditykeeper "github.com/crescent-network/crescent/v5/x/liquidity/keeper"
 	liquiditytypes "github.com/crescent-network/crescent/v5/x/liquidity/types"
 	lpfarmkeeper "github.com/crescent-network/crescent/v5/x/lpfarm/keeper"
@@ -38,6 +39,7 @@ var StoreUpgrades = store.StoreUpgrades{
 		markertypes.StoreKey,
 		exchangetypes.StoreKey,
 		ammtypes.StoreKey,
+		liquidammtypes.StoreKey,
 	},
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- During revert liquidfarming + add liquidamm module, there was an issue where liquidamm store key was missing in v5 `StoreUpgrades`

## References

- https://github.com/crescent-network/crescent/pull/171

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/v0.45.9/docs/building-modules/README.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
