### PR TITLE
fix: do not update matching height when there's no matching

### DIFF
--- a/x/exchange/types/matching.go
+++ b/x/exchange/types/matching.go
@@ -200,7 +200,7 @@ func (ctx *MatchingContext) ExecuteOrder(
 	return
 }
 
-func (ctx *MatchingContext) RunSinglePriceAuction(buyObs, sellObs *MemOrderBookSide) (matchPrice sdk.Dec) {
+func (ctx *MatchingContext) RunSinglePriceAuction(buyObs, sellObs *MemOrderBookSide) (matchPrice sdk.Dec, matched bool) {
 	buyLevelIdx, sellLevelIdx := 0, 0
 	var buyLastPrice, sellLastPrice sdk.Dec
 	for buyLevelIdx < len(buyObs.levels) && sellLevelIdx < len(sellObs.levels) {
@@ -241,11 +241,12 @@ func (ctx *MatchingContext) RunSinglePriceAuction(buyObs, sellObs *MemOrderBookS
 				sellLevelIdx++
 			}
 		}
+		matched = true
 	}
 	return
 }
 
-func (ctx *MatchingContext) BatchMatchOrderBookSides(buyObs, sellObs *MemOrderBookSide, lastPrice sdk.Dec) (newLastPrice sdk.Dec) {
+func (ctx *MatchingContext) BatchMatchOrderBookSides(buyObs, sellObs *MemOrderBookSide, lastPrice sdk.Dec) (newLastPrice sdk.Dec, matched bool) {
 	// Phase 1: Match orders with price below(or equal to) the last price and
 	// price above(or equal to) the last price.
 	// The execution price is the last price.
@@ -264,10 +265,11 @@ func (ctx *MatchingContext) BatchMatchOrderBookSides(buyObs, sellObs *MemOrderBo
 		if sellFull {
 			sellLevelIdx++
 		}
+		matched = true
 	}
 	// If there's no more levels to match, return earlier.
 	if buyLevelIdx >= len(buyObs.levels) || sellLevelIdx >= len(sellObs.levels) {
-		return lastPrice
+		return lastPrice, matched
 	}
 
 	// Phase 2: Match orders in traditional exchange's manner.
@@ -296,8 +298,9 @@ func (ctx *MatchingContext) BatchMatchOrderBookSides(buyObs, sellObs *MemOrderBo
 		if sellFull {
 			sellLevelIdx++
 		}
+		matched = true
 	}
-	return newLastPrice
+	return newLastPrice, matched
 }
 
 func PayReceiveDenoms(baseDenom, quoteDenom string, isBuy bool) (payDenom, receiveDenom string) {


### PR DESCRIPTION
## Description

If there was no matching in batch phase, do not update `LastMatchingHeight`. Previously, it has been updated in every block.