### PR TITLE
refactor: improve pool order performance

### DIFF
--- a/app/upgrades/mainnet/v5/upgrade.go
+++ b/app/upgrades/mainnet/v5/upgrade.go
@@ -295,8 +295,8 @@ func UpgradeHandler(
 					newPoolId := newPoolIdByPairId[pairIdByOldPoolId[oldPoolId]]
 					var lowerPrice, upperPrice sdk.Dec
 					if oldPool.Type == liquiditytypes.PoolTypeBasic {
-						lowerPrice = exchangetypes.PriceAtTick(ammtypes.MinTick)
-						upperPrice = exchangetypes.PriceAtTick(ammtypes.MaxTick)
+						lowerPrice = ammtypes.MinPrice
+						upperPrice = ammtypes.MaxPrice
 					} else { // the pool is a ranged pool
 						lowerPrice = exchangetypes.PriceAtTick(
 							ammtypes.AdjustPriceToTickSpacing(*oldPool.MinPrice, defaultTickSpacing, false))

--- a/app/upgrades/mainnet/v5/upgrade.go
+++ b/app/upgrades/mainnet/v5/upgrade.go
@@ -299,11 +299,9 @@ func UpgradeHandler(
 						upperPrice = exchangetypes.PriceAtTick(ammtypes.MaxTick)
 					} else { // the pool is a ranged pool
 						lowerPrice = exchangetypes.PriceAtTick(
-							ammtypes.AdjustTickToTickSpacing(
-								exchangetypes.TickAtPrice(*oldPool.MinPrice), defaultTickSpacing, false))
+							ammtypes.AdjustPriceToTickSpacing(*oldPool.MinPrice, defaultTickSpacing, false))
 						upperPrice = exchangetypes.PriceAtTick(
-							ammtypes.AdjustTickToTickSpacing(
-								exchangetypes.TickAtPrice(*oldPool.MaxPrice), defaultTickSpacing, true))
+							ammtypes.AdjustPriceToTickSpacing(*oldPool.MaxPrice, defaultTickSpacing, true))
 					}
 					if _, _, _, err := ammKeeper.AddLiquidity(
 						ctx, addr, addr, newPoolId, lowerPrice, upperPrice, req.WithdrawnCoins); err != nil {

--- a/x/amm/keeper/order_test.go
+++ b/x/amm/keeper/order_test.go
@@ -34,8 +34,7 @@ func BenchmarkPlaceMarketOrder(b *testing.B) {
 	pool, err := app.AMMKeeper.CreatePool(ctx, creatorAddr, market.Id, utils.ParseDec("5"))
 	require.NoError(b, err)
 	_, _, _, err = app.AMMKeeper.AddLiquidity(
-		ctx, creatorAddr, creatorAddr, pool.Id,
-		exchangetypes.PriceAtTick(types.MinTick), exchangetypes.PriceAtTick(types.MaxTick),
+		ctx, creatorAddr, creatorAddr, pool.Id, types.MinPrice, types.MaxPrice,
 		utils.ParseCoins("10_000000ucre,50_000000uusd"))
 	require.NoError(b, err)
 

--- a/x/amm/keeper/pool_bench_test.go
+++ b/x/amm/keeper/pool_bench_test.go
@@ -1,0 +1,96 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	chain "github.com/crescent-network/crescent/v5/app"
+	utils "github.com/crescent-network/crescent/v5/types"
+	"github.com/crescent-network/crescent/v5/x/amm/types"
+)
+
+func BenchmarkPoolOrders(b *testing.B) {
+	app := chain.Setup(false)
+	ctx := app.NewContext(false, tmproto.Header{
+		Height: 0,
+		Time:   utils.ParseTime("2023-01-01T00:00:00Z"),
+	})
+
+	creatorAddr := utils.TestAddress(0)
+	require.NoError(
+		b, chain.FundAccount(app.BankKeeper, ctx, creatorAddr, enoughCoins))
+
+	market, err := app.ExchangeKeeper.CreateMarket(ctx, creatorAddr, "ucre", "uusd")
+	require.NoError(b, err)
+
+	pool, err := app.AMMKeeper.CreatePool(ctx, creatorAddr, market.Id, utils.ParseDec("5"))
+	require.NoError(b, err)
+
+	lpAddr := utils.TestAddress(1)
+	require.NoError(b, chain.FundAccount(app.BankKeeper, ctx, lpAddr, enoughCoins))
+
+	_, _, _, err = app.AMMKeeper.AddLiquidity(
+		ctx, lpAddr, lpAddr, pool.Id, types.MinPrice, types.MaxPrice,
+		utils.ParseCoins("10_000000ucre,50_000000uusd"))
+	require.NoError(b, err)
+
+	ordererAddr := utils.TestAddress(2)
+	require.NoError(b, chain.FundAccount(app.BankKeeper, ctx, ordererAddr, enoughCoins))
+	b.ResetTimer()
+
+	b.Run("buy", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cacheCtx, _ := ctx.CacheContext()
+			_, _, err := app.ExchangeKeeper.PlaceMarketOrder(cacheCtx, market.Id, ordererAddr, true, sdk.NewDec(5_000000))
+			require.NoError(b, err)
+		}
+	})
+	b.Run("sell", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cacheCtx, _ := ctx.CacheContext()
+			_, _, err := app.ExchangeKeeper.PlaceMarketOrder(cacheCtx, market.Id, ordererAddr, false, sdk.NewDec(5_000000))
+			require.NoError(b, err)
+		}
+	})
+}
+
+// XXX
+func BenchmarkPlaceBuyMarketOrder(b *testing.B) {
+	app := chain.Setup(false)
+	ctx := app.NewContext(false, tmproto.Header{
+		Height: 0,
+		Time:   utils.ParseTime("2023-01-01T00:00:00Z"),
+	})
+
+	creatorAddr := utils.TestAddress(0)
+	require.NoError(
+		b, chain.FundAccount(app.BankKeeper, ctx, creatorAddr, enoughCoins))
+
+	market, err := app.ExchangeKeeper.CreateMarket(ctx, creatorAddr, "ucre", "uusd")
+	require.NoError(b, err)
+
+	pool, err := app.AMMKeeper.CreatePool(ctx, creatorAddr, market.Id, utils.ParseDec("5"))
+	require.NoError(b, err)
+
+	lpAddr := utils.TestAddress(1)
+	require.NoError(b, chain.FundAccount(app.BankKeeper, ctx, lpAddr, enoughCoins))
+
+	_, _, _, err = app.AMMKeeper.AddLiquidity(
+		ctx, lpAddr, lpAddr, pool.Id, types.MinPrice, types.MaxPrice,
+		utils.ParseCoins("10_000000ucre,50_000000uusd"))
+	require.NoError(b, err)
+
+	ordererAddr := utils.TestAddress(2)
+	require.NoError(b, chain.FundAccount(app.BankKeeper, ctx, ordererAddr, enoughCoins))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cacheCtx, _ := ctx.CacheContext()
+		_, _, err := app.ExchangeKeeper.PlaceMarketOrder(cacheCtx, market.Id, ordererAddr, true, sdk.NewDec(100_000000))
+		require.NoError(b, err)
+	}
+}

--- a/x/amm/keeper/pool_test.go
+++ b/x/amm/keeper/pool_test.go
@@ -1,10 +1,15 @@
 package keeper_test
 
 import (
+	"testing"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	chain "github.com/crescent-network/crescent/v5/app"
 	utils "github.com/crescent-network/crescent/v5/types"
 	"github.com/crescent-network/crescent/v5/x/amm/types"
 	exchangetypes "github.com/crescent-network/crescent/v5/x/exchange/types"
@@ -198,4 +203,49 @@ func (s *KeeperTestSuite) TestSwapEdgecase1() {
 		market.Id, ordererAddr, false, utils.ParseDec("45.821"), utils.ParseDec("39636169.911478604318885683"), time.Hour)
 
 	s.SwapExactAmountIn(ordererAddr, []uint64{market.Id}, utils.ParseDecCoin("35987097uusd"), utils.ParseDecCoin("0ucre"), false)
+}
+
+func BenchmarkPoolOrders(b *testing.B) {
+	app := chain.Setup(false)
+	ctx := app.NewContext(false, tmproto.Header{
+		Height: 0,
+		Time:   utils.ParseTime("2023-01-01T00:00:00Z"),
+	})
+
+	creatorAddr := utils.TestAddress(0)
+	require.NoError(
+		b, chain.FundAccount(app.BankKeeper, ctx, creatorAddr, enoughCoins))
+
+	market, err := app.ExchangeKeeper.CreateMarket(ctx, creatorAddr, "ucre", "uusd")
+	require.NoError(b, err)
+
+	pool, err := app.AMMKeeper.CreatePool(ctx, creatorAddr, market.Id, utils.ParseDec("5"))
+	require.NoError(b, err)
+
+	lpAddr := utils.TestAddress(1)
+	require.NoError(b, chain.FundAccount(app.BankKeeper, ctx, lpAddr, enoughCoins))
+
+	_, _, _, err = app.AMMKeeper.AddLiquidity(
+		ctx, lpAddr, lpAddr, pool.Id, exchangetypes.PriceAtTick(types.MinTick), exchangetypes.PriceAtTick(types.MaxTick),
+		utils.ParseCoins("10_000000ucre,50_000000uusd"))
+	require.NoError(b, err)
+
+	ordererAddr := utils.TestAddress(2)
+	require.NoError(b, chain.FundAccount(app.BankKeeper, ctx, ordererAddr, enoughCoins))
+	b.ResetTimer()
+
+	b.Run("buy", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cacheCtx, _ := ctx.CacheContext()
+			_, _, err := app.ExchangeKeeper.PlaceMarketOrder(cacheCtx, market.Id, ordererAddr, true, sdk.NewDec(5_000000))
+			require.NoError(b, err)
+		}
+	})
+	b.Run("sell", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cacheCtx, _ := ctx.CacheContext()
+			_, _, err := app.ExchangeKeeper.PlaceMarketOrder(cacheCtx, market.Id, ordererAddr, false, sdk.NewDec(5_000000))
+			require.NoError(b, err)
+		}
+	})
 }

--- a/x/amm/keeper/pool_test.go
+++ b/x/amm/keeper/pool_test.go
@@ -1,15 +1,10 @@
 package keeper_test
 
 import (
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	chain "github.com/crescent-network/crescent/v5/app"
 	utils "github.com/crescent-network/crescent/v5/types"
 	"github.com/crescent-network/crescent/v5/x/amm/types"
 	exchangetypes "github.com/crescent-network/crescent/v5/x/exchange/types"
@@ -203,49 +198,4 @@ func (s *KeeperTestSuite) TestSwapEdgecase1() {
 		market.Id, ordererAddr, false, utils.ParseDec("45.821"), utils.ParseDec("39636169.911478604318885683"), time.Hour)
 
 	s.SwapExactAmountIn(ordererAddr, []uint64{market.Id}, utils.ParseDecCoin("35987097uusd"), utils.ParseDecCoin("0ucre"), false)
-}
-
-func BenchmarkPoolOrders(b *testing.B) {
-	app := chain.Setup(false)
-	ctx := app.NewContext(false, tmproto.Header{
-		Height: 0,
-		Time:   utils.ParseTime("2023-01-01T00:00:00Z"),
-	})
-
-	creatorAddr := utils.TestAddress(0)
-	require.NoError(
-		b, chain.FundAccount(app.BankKeeper, ctx, creatorAddr, enoughCoins))
-
-	market, err := app.ExchangeKeeper.CreateMarket(ctx, creatorAddr, "ucre", "uusd")
-	require.NoError(b, err)
-
-	pool, err := app.AMMKeeper.CreatePool(ctx, creatorAddr, market.Id, utils.ParseDec("5"))
-	require.NoError(b, err)
-
-	lpAddr := utils.TestAddress(1)
-	require.NoError(b, chain.FundAccount(app.BankKeeper, ctx, lpAddr, enoughCoins))
-
-	_, _, _, err = app.AMMKeeper.AddLiquidity(
-		ctx, lpAddr, lpAddr, pool.Id, exchangetypes.PriceAtTick(types.MinTick), exchangetypes.PriceAtTick(types.MaxTick),
-		utils.ParseCoins("10_000000ucre,50_000000uusd"))
-	require.NoError(b, err)
-
-	ordererAddr := utils.TestAddress(2)
-	require.NoError(b, chain.FundAccount(app.BankKeeper, ctx, ordererAddr, enoughCoins))
-	b.ResetTimer()
-
-	b.Run("buy", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			cacheCtx, _ := ctx.CacheContext()
-			_, _, err := app.ExchangeKeeper.PlaceMarketOrder(cacheCtx, market.Id, ordererAddr, true, sdk.NewDec(5_000000))
-			require.NoError(b, err)
-		}
-	})
-	b.Run("sell", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			cacheCtx, _ := ctx.CacheContext()
-			_, _, err := app.ExchangeKeeper.PlaceMarketOrder(cacheCtx, market.Id, ordererAddr, false, sdk.NewDec(5_000000))
-			require.NoError(b, err)
-		}
-	})
 }

--- a/x/amm/simulation/operations.go
+++ b/x/amm/simulation/operations.go
@@ -239,7 +239,7 @@ func findMsgAddLiquidityParams(
 				poolState := k.MustGetPoolState(ctx, pool.Id)
 				var lowerPrice, upperPrice sdk.Dec
 				if r.Float64() <= 0.2 {
-					lowerPrice = exchangetypes.PriceAtTick(types.MinTick)
+					lowerPrice = types.MinPrice
 				} else if r.Float64() <= 0.5 {
 					lowerPrice = exchangetypes.PriceAtTick(
 						exchangetypes.TickAtPrice(
@@ -254,7 +254,7 @@ func findMsgAddLiquidityParams(
 								poolState.CurrentPrice.Mul(utils.ParseDec("1.5")))) / ts * ts)
 				}
 				if r.Float64() <= 0.2 {
-					upperPrice = exchangetypes.PriceAtTick(types.MaxTick)
+					upperPrice = types.MaxPrice
 				} else {
 					upperPrice = exchangetypes.PriceAtTick(
 						exchangetypes.TickAtPrice(

--- a/x/amm/types/math_test.go
+++ b/x/amm/types/math_test.go
@@ -10,7 +10,6 @@ import (
 
 	utils "github.com/crescent-network/crescent/v5/types"
 	"github.com/crescent-network/crescent/v5/x/amm/types"
-	exchangetypes "github.com/crescent-network/crescent/v5/x/exchange/types"
 )
 
 func TestLiquidityForAmounts(t *testing.T) {

--- a/x/amm/types/math_test.go
+++ b/x/amm/types/math_test.go
@@ -31,7 +31,7 @@ func TestLiquidityForAmounts(t *testing.T) {
 		},
 		{
 			utils.ParseDec("1"),
-			exchangetypes.PriceAtTick(types.MinTick), exchangetypes.PriceAtTick(types.MaxTick),
+			types.MinPrice, types.MaxPrice,
 			sdk.NewInt(100_000000), sdk.NewInt(100_000000),
 			sdk.NewInt(100000000),
 		},

--- a/x/amm/types/params.go
+++ b/x/amm/types/params.go
@@ -6,13 +6,20 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	exchangetypes "github.com/crescent-network/crescent/v5/x/exchange/types"
 )
 
 var _ paramstypes.ParamSet = (*Params)(nil)
 
 const (
-	MinTick = -1260000 // 0.000000000000010000
-	MaxTick = 3600000  // 10000000000000000000000000000000000000000
+	MinTick = -1260000
+	MaxTick = 3600000
+)
+
+var (
+	MinPrice = exchangetypes.PriceAtTick(MinTick) // 0.000000000000010000
+	MaxPrice = exchangetypes.PriceAtTick(MaxTick) // 10000000000000000000000000000000000000000
 )
 
 var (

--- a/x/amm/types/tick.go
+++ b/x/amm/types/tick.go
@@ -24,15 +24,18 @@ func AdjustTickToTickSpacing(tick int32, tickSpacing uint32, roundUp bool) int32
 	return q * ts
 }
 
-// NextTick returns the next tick based on tickSpacing.
-// If up is true, then the next up tick is returned.
-// If up is false, then the next down tick is returned.
-func NextTick(tick int32, tickSpacing uint32, up bool) int32 {
-	tick = AdjustTickToTickSpacing(tick, tickSpacing, !up)
-	if up {
-		return tick + int32(tickSpacing)
+func AdjustPriceToTickSpacing(price sdk.Dec, tickSpacing uint32, roundUp bool) int32 {
+	ts := int32(tickSpacing)
+	tick, valid := exchangetypes.ValidateTickPrice(price)
+	if roundUp {
+		q, _ := utils.DivMod(tick+ts-1, ts)
+		if !valid && tick%ts == 0 {
+			q++
+		}
+		return q * ts
 	}
-	return tick - int32(tickSpacing)
+	q, _ := utils.DivMod(tick, ts)
+	return q * ts
 }
 
 func NewTickInfo(grossLiquidity, netLiquidity sdk.Int) TickInfo {

--- a/x/amm/types/tick_test.go
+++ b/x/amm/types/tick_test.go
@@ -13,7 +13,7 @@ import (
 	exchangetypes "github.com/crescent-network/crescent/v5/x/exchange/types"
 )
 
-func TestAdjustPriceToTickSpacing(t *testing.T) {
+func TestAdjustTickToTickSpacing(t *testing.T) {
 	tickSpacing := uint32(10)
 	for i, tc := range []struct {
 		price    sdk.Dec

--- a/x/exchange/keeper/batch.go
+++ b/x/exchange/keeper/batch.go
@@ -17,6 +17,9 @@ func (k Keeper) RunBatchMatching(ctx sdk.Context, market types.Market) (err erro
 	if !found { // Nothing to match, exit early
 		return nil
 	}
+	if bestBuyPrice.LT(bestSellPrice) {
+		return nil
+	}
 
 	// Construct order book sides with the price limits we obtained previously.
 	escrow := types.NewEscrow(market.MustGetEscrowAddress())

--- a/x/exchange/keeper/order.go
+++ b/x/exchange/keeper/order.go
@@ -200,10 +200,16 @@ func (k Keeper) PlaceMarketOrder(
 	}
 
 	orderId = k.GetNextOrderIdWithUpdate(ctx)
+	var quoteLimit *sdk.Dec
+	if isBuy {
+		quote := k.bankKeeper.SpendableCoins(ctx, ordererAddr).AmountOf(market.QuoteDenom).ToDec()
+		quoteLimit = &quote
+	}
 	res, err = k.executeOrder(
 		ctx, market, ordererAddr, types.MemOrderBookSideOptions{
 			IsBuy:         !isBuy,
 			QuantityLimit: &qty,
+			QuoteLimit:    quoteLimit,
 		}, false, false)
 	if err != nil {
 		return


### PR DESCRIPTION
## Description

Improve pool order performance by finding the next order price derived by current pool state.
Also, pass `quoteLimit` properly for buy orders.