### PR TITLE
refactor: safely run batch matching using cached ctx

### DIFF
--- a/x/exchange/abci.go
+++ b/x/exchange/abci.go
@@ -24,10 +24,24 @@ func MidBlocker(ctx sdk.Context, k keeper.Keeper) {
 	// market's order book is not crossed.
 	// We could further optimize the process by settings transient flag
 	// when we receive batch order msgs.
+	var markets []types.Market
 	k.IterateAllMarkets(ctx, func(market types.Market) (stop bool) {
-		if err := k.RunBatchMatching(ctx, market); err != nil {
-			panic(err)
-		}
+		markets = append(markets, market)
 		return false
 	})
+	for _, market := range markets {
+		cacheCtx, writeCache := ctx.CacheContext()
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					k.Logger(ctx).Error("panic in batch matching", "value", r)
+				}
+			}()
+			if err := k.RunBatchMatching(cacheCtx, market); err != nil {
+				k.Logger(ctx).Error("failed to run batch matching", "error", err)
+			} else {
+				writeCache()
+			}
+		}()
+	}
 }


### PR DESCRIPTION
## Description

To prevent a chain halt caused by an uncaught error from `RunBatchMatching`, use cached context and recover panics from it.