### PR TITLE
fix: fix bug in order book query and IteratePoolOrders

### DIFF
--- a/x/amm/keeper/grpc_query_test.go
+++ b/x/amm/keeper/grpc_query_test.go
@@ -5,6 +5,8 @@ import (
 
 	utils "github.com/crescent-network/crescent/v5/types"
 	"github.com/crescent-network/crescent/v5/x/amm/types"
+	exchangekeeper "github.com/crescent-network/crescent/v5/x/exchange/keeper"
+	exchangetypes "github.com/crescent-network/crescent/v5/x/exchange/types"
 )
 
 // SetupSampleScenario creates markets, pools and positions for query tests.
@@ -891,5 +893,47 @@ func (s *KeeperTestSuite) TestQueryFarmingPlan() {
 				s.Require().EqualError(err, tc.expectedErr)
 			}
 		})
+	}
+}
+
+func (s *KeeperTestSuite) TestQueryOrderBookEdgecase() {
+	market, pool := s.CreateMarketAndPool("ucre", "uusd", utils.ParseDec("0.000000000002410188"))
+
+	lpAddr := s.FundedAccount(1, enoughCoins)
+	amt0, amt1 := types.AmountsForLiquidity(
+		utils.DecApproxSqrt(utils.ParseDec("0.000000000002410188")),
+		utils.DecApproxSqrt(types.MinPrice),
+		utils.DecApproxSqrt(types.MaxPrice),
+		sdk.NewInt(160843141868))
+	s.AddLiquidity(
+		lpAddr, pool.Id, types.MinPrice, types.MaxPrice,
+		sdk.NewCoins(sdk.NewCoin(pool.Denom0, amt0), sdk.NewCoin(pool.Denom1, amt1)))
+
+	querier := exchangekeeper.Querier{Keeper: s.App.ExchangeKeeper}
+	resp, err := querier.OrderBook(sdk.WrapSDKContext(s.Ctx), &exchangetypes.QueryOrderBookRequest{
+		MarketId: market.Id,
+	})
+	s.Require().NoError(err)
+	expected := []exchangetypes.OrderBookPriceLevel{
+		{utils.ParseDec("0.000000000002420000"), utils.ParseDec("210247167454518.426965889361986342")},
+		{utils.ParseDec("0.000000000002425000"), utils.ParseDec("106646637502197.215845362922175345")},
+		{utils.ParseDec("0.000000000002430000"), utils.ParseDec("106317311667972.575612265795090924")},
+		{utils.ParseDec("0.000000000002435000"), utils.ParseDec("105989677315106.625670065116473178")},
+	}
+	s.Require().GreaterOrEqual(len(resp.OrderBooks[0].Sells), len(expected))
+	for i, level := range expected {
+		s.AssertEqual(level.P, resp.OrderBooks[0].Sells[i].P)
+		s.AssertEqual(level.Q, resp.OrderBooks[0].Sells[i].Q)
+	}
+	expected = []exchangetypes.OrderBookPriceLevel{
+		{utils.ParseDec("0.000000000002410000"), utils.ParseDec("4041069947696.441682987551867219")},
+		{utils.ParseDec("0.000000000002405000"), utils.ParseDec("107756725726365.156645322245322245")},
+		{utils.ParseDec("0.000000000002400000"), utils.ParseDec("108093523942782.413913333333333333")},
+		{utils.ParseDec("0.000000000002395000"), utils.ParseDec("108432080322133.934602087682672233")},
+	}
+	s.Require().GreaterOrEqual(len(resp.OrderBooks[0].Buys), len(expected))
+	for i, level := range expected {
+		s.AssertEqual(level.P, resp.OrderBooks[0].Buys[i].P)
+		s.AssertEqual(level.Q, resp.OrderBooks[0].Buys[i].Q)
 	}
 }

--- a/x/amm/keeper/grpc_query_test.go
+++ b/x/amm/keeper/grpc_query_test.go
@@ -915,10 +915,10 @@ func (s *KeeperTestSuite) TestQueryOrderBookEdgecase() {
 	})
 	s.Require().NoError(err)
 	expected := []exchangetypes.OrderBookPriceLevel{
-		{utils.ParseDec("0.000000000002420000"), utils.ParseDec("210247167454518.426965889361986342")},
-		{utils.ParseDec("0.000000000002425000"), utils.ParseDec("106646637502197.215845362922175345")},
-		{utils.ParseDec("0.000000000002430000"), utils.ParseDec("106317311667972.575612265795090924")},
-		{utils.ParseDec("0.000000000002435000"), utils.ParseDec("105989677315106.625670065116473178")},
+		{P: utils.ParseDec("0.000000000002420000"), Q: utils.ParseDec("210247167454518.426965889361986342")},
+		{P: utils.ParseDec("0.000000000002425000"), Q: utils.ParseDec("106646637502197.215845362922175345")},
+		{P: utils.ParseDec("0.000000000002430000"), Q: utils.ParseDec("106317311667972.575612265795090924")},
+		{P: utils.ParseDec("0.000000000002435000"), Q: utils.ParseDec("105989677315106.625670065116473178")},
 	}
 	s.Require().GreaterOrEqual(len(resp.OrderBooks[0].Sells), len(expected))
 	for i, level := range expected {
@@ -926,10 +926,10 @@ func (s *KeeperTestSuite) TestQueryOrderBookEdgecase() {
 		s.AssertEqual(level.Q, resp.OrderBooks[0].Sells[i].Q)
 	}
 	expected = []exchangetypes.OrderBookPriceLevel{
-		{utils.ParseDec("0.000000000002410000"), utils.ParseDec("4041069947696.441682987551867219")},
-		{utils.ParseDec("0.000000000002405000"), utils.ParseDec("107756725726365.156645322245322245")},
-		{utils.ParseDec("0.000000000002400000"), utils.ParseDec("108093523942782.413913333333333333")},
-		{utils.ParseDec("0.000000000002395000"), utils.ParseDec("108432080322133.934602087682672233")},
+		{P: utils.ParseDec("0.000000000002410000"), Q: utils.ParseDec("4041069947696.441682987551867219")},
+		{P: utils.ParseDec("0.000000000002405000"), Q: utils.ParseDec("107756725726365.156645322245322245")},
+		{P: utils.ParseDec("0.000000000002400000"), Q: utils.ParseDec("108093523942782.413913333333333333")},
+		{P: utils.ParseDec("0.000000000002395000"), Q: utils.ParseDec("108432080322133.934602087682672233")},
 	}
 	s.Require().GreaterOrEqual(len(resp.OrderBooks[0].Buys), len(expected))
 	for i, level := range expected {
@@ -957,7 +957,7 @@ func (s *KeeperTestSuite) TestQueryOrderBookEdgecase2() {
 	})
 	s.Require().NoError(err)
 	expected := []exchangetypes.OrderBookPriceLevel{
-		{utils.ParseDec("1000000000000000000000000000000000000.000000000000000000"), utils.ParseDec("9.014670721835706842")},
+		{P: utils.ParseDec("1000000000000000000000000000000000000.000000000000000000"), Q: utils.ParseDec("9.014670721835706842")},
 	}
 	s.Require().GreaterOrEqual(len(resp.OrderBooks[0].Sells), len(expected))
 	for i, level := range expected {

--- a/x/amm/keeper/pool.go
+++ b/x/amm/keeper/pool.go
@@ -140,10 +140,13 @@ func NextOrderTick(
 			return 0, false
 		}
 		orderPrice := sdk.MinDec(orderSqrtPrice, orderSqrtPrice2).Power(2)
-		if orderPrice.GTE(currentPrice) {
+		if orderPrice.GT(currentPrice) {
 			return 0, false
 		}
 		tick = types.AdjustPriceToTickSpacing(orderPrice, tickSpacing, false)
+		if orderPrice.Equal(currentPrice) { // This implies PriceAtTick(tick) == currentPrice
+			tick -= int32(tickSpacing)
+		}
 		return tick, true
 	}
 	// 1. Check min order qty
@@ -158,9 +161,12 @@ func NextOrderTick(
 		return 0, false
 	}
 	orderPrice := sdk.MaxDec(orderSqrtPrice, orderSqrtPrice2).Power(2)
-	if orderPrice.LTE(currentPrice) {
+	if orderPrice.LT(currentPrice) {
 		return 0, false
 	}
 	tick = types.AdjustPriceToTickSpacing(orderPrice, tickSpacing, true)
+	if orderPrice.Equal(currentPrice) { // This implies PriceAtTick(tick) == currentPrice
+		tick += int32(tickSpacing)
+	}
 	return tick, true
 }

--- a/x/amm/types/tick_test.go
+++ b/x/amm/types/tick_test.go
@@ -44,6 +44,32 @@ func TestAdjustTickToTickSpacing(t *testing.T) {
 	}
 }
 
+func TestAdjustPriceToTickSpacing(t *testing.T) {
+	for i, tc := range []struct {
+		price    sdk.Dec
+		roundUp  bool
+		expected sdk.Dec
+	}{
+		{utils.ParseDec("12345"), true, utils.ParseDec("12350")},
+		{utils.ParseDec("12345"), false, utils.ParseDec("12300")},
+		{utils.ParseDec("12350.1"), true, utils.ParseDec("12400")},
+		{utils.ParseDec("12350.1"), false, utils.ParseDec("12350")},
+		{utils.ParseDec("12350"), true, utils.ParseDec("12350")},
+		{utils.ParseDec("12350"), false, utils.ParseDec("12350")},
+		{utils.ParseDec("0.00012345"), true, utils.ParseDec("0.00012350")},
+		{utils.ParseDec("0.00012345"), false, utils.ParseDec("0.00012300")},
+		{utils.ParseDec("0.000123501"), true, utils.ParseDec("0.00012400")},
+		{utils.ParseDec("0.000123501"), false, utils.ParseDec("0.00012350")},
+		{utils.ParseDec("0.00012350"), true, utils.ParseDec("0.00012350")},
+		{utils.ParseDec("0.00012350"), false, utils.ParseDec("0.00012350")},
+	} {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			tick := types.AdjustPriceToTickSpacing(tc.price, 50, tc.roundUp)
+			require.True(sdk.DecEq(t, tc.expected, exchangetypes.PriceAtTick(tick)))
+		})
+	}
+}
+
 func TestTickInfo_Validate(t *testing.T) {
 	for _, tc := range []struct {
 		name        string


### PR DESCRIPTION
## Description

Handle edge case when `orderPrice == currentPrice`. And also handle non-positive order book price when querying order books.