### PR TITLE
fix: set last market id in upgrade handler

### DIFF
--- a/app/upgrades/mainnet/v5/upgrade.go
+++ b/app/upgrades/mainnet/v5/upgrade.go
@@ -152,6 +152,7 @@ func UpgradeHandler(
 		defaultOrderSourceFeeRatio := exchangeParams.Fees.DefaultOrderSourceFeeRatio
 		pairs := map[uint64]liquiditytypes.Pair{}
 		var pairIds []uint64 // For ordered map access
+		var lastMarketId uint64
 		if err := liquidityKeeper.IterateAllPairs(ctx, func(pair liquiditytypes.Pair) (stop bool, err error) {
 			// Cache pairs for later iteration.
 			pairs[pair.Id] = pair
@@ -188,10 +189,12 @@ func UpgradeHandler(
 			exchangeKeeper.SetMarket(ctx, market)
 			exchangeKeeper.SetMarketByDenomsIndex(ctx, market)
 			exchangeKeeper.SetMarketState(ctx, market.Id, exchangetypes.NewMarketState(pair.LastPrice))
+			lastMarketId = pair.Id
 			return false, nil
 		}); err != nil {
 			return nil, err
 		}
+		exchangeKeeper.SetLastMarketId(ctx, lastMarketId)
 
 		// Create a new pool for each market if the market's corresponding pair
 		// had at least one active pool.

--- a/app/upgrades/mainnet/v5/upgrade_test.go
+++ b/app/upgrades/mainnet/v5/upgrade_test.go
@@ -68,4 +68,12 @@ func (s *UpgradeTestSuite) TestUpgradeV5() {
 	poolState := s.App.AMMKeeper.MustGetPoolState(s.Ctx, pool.Id)
 	s.AssertEqual(sdk.NewInt(2341640785), poolState.TotalLiquidity)
 	s.AssertEqual(sdk.NewInt(2341640785), poolState.CurrentLiquidity)
+
+	// Check if creating new market overwrites existing markets.
+	s.Require().Equal(uint64(1), s.App.ExchangeKeeper.GetLastMarketId(s.Ctx))
+	market := s.CreateMarket("uusd", "ucre")
+	s.Require().Equal(uint64(2), market.Id)
+	market, _ = s.App.ExchangeKeeper.GetMarket(s.Ctx, 1)
+	s.Require().Equal("ucre", market.BaseDenom)
+	s.Require().Equal("uusd", market.QuoteDenom)
 }


### PR DESCRIPTION
## Description

Currently `LastMarketId` is not being updated in the upgrade handler, so if someone creates a new market after upgrade, then the existing markets would be overwritten since the new market's id would start from 1 again. This PR fixes the bug by correctly setting last market id.