### PR TITLE
fix: limit market orders' price impact to MaxOrderPriceRatio

### DIFF
--- a/x/amm/keeper/farming_test.go
+++ b/x/amm/keeper/farming_test.go
@@ -219,7 +219,8 @@ func (s *KeeperTestSuite) TestFarming() {
 	s.Collect(lpAddr2, position2.Id, utils.ParseCoins("47uatom"))
 
 	ordererAddr := s.FundedAccount(3, utils.ParseCoins("10000_000000uusd"))
-	s.PlaceMarketOrder(pool.MarketId, ordererAddr, true, sdk.NewDec(120_000000))
+	s.PlaceLimitOrder(
+		pool.MarketId, ordererAddr, true, utils.ParseDec("6"), sdk.NewDec(120_000000), 0)
 
 	poolState := s.App.AMMKeeper.MustGetPoolState(s.Ctx, pool.Id)
 	fmt.Println(poolState.CurrentPrice)

--- a/x/amm/keeper/order_test.go
+++ b/x/amm/keeper/order_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -116,8 +115,8 @@ func (s *KeeperTestSuite) TestOrderGas() {
 	}
 	ordererAddr := s.FundedAccount(2, enoughCoins)
 	gasConsumedBefore := s.Ctx.GasMeter().GasConsumed()
-	s.PlaceMarketOrder(market.Id, ordererAddr, true, sdk.NewDec(50_000000))
-	fmt.Println(s.Ctx.GasMeter().GasConsumed() - gasConsumedBefore)
+	s.PlaceLimitOrder(market.Id, ordererAddr, true, utils.ParseDec("150.5"), sdk.NewDec(50_000000), 0)
+	s.Require().Less(s.Ctx.GasMeter().GasConsumed()-gasConsumedBefore, uint64(200000))
 }
 
 func (s *KeeperTestSuite) TestCurrentLiquidityEdgecase() {
@@ -134,7 +133,7 @@ func (s *KeeperTestSuite) TestCurrentLiquidityEdgecase() {
 	ordererAddr := s.FundedAccount(2, enoughCoins)
 	s.PlaceLimitOrder(market.Id, ordererAddr, true, utils.ParseDec("4.99"), sdk.NewDec(5988301+1), time.Hour)
 
-	s.PlaceMarketOrder(market.Id, ordererAddr, false, sdk.NewDec(5979313+5988301*2+1000))
+	s.PlaceLimitOrder(market.Id, ordererAddr, false, utils.ParseDec("4.8"), sdk.NewDec(5979313+5988301*2+1000), 0)
 	_, broken := keeper.PoolCurrentLiquidityInvariant(s.keeper)(s.Ctx)
 	s.Require().False(broken)
 }

--- a/x/amm/keeper/position_test.go
+++ b/x/amm/keeper/position_test.go
@@ -32,7 +32,7 @@ func (s *KeeperTestSuite) TestReinitializePosition() {
 		ownerAddr, pool.Id, lowerPrice, upperPrice, desiredAmt)
 
 	ordererAddr := s.FundedAccount(2, enoughCoins)
-	s.PlaceMarketOrder(market.Id, ordererAddr, true, sdk.NewDec(1000000))
+	s.PlaceLimitOrder(market.Id, ordererAddr, true, utils.ParseDec("6"), sdk.NewDec(1000000), 0)
 	s.PlaceMarketOrder(market.Id, ordererAddr, false, sdk.NewDec(1000000))
 
 	s.RemoveLiquidity(ownerAddr, position.Id, liquidity)
@@ -51,7 +51,7 @@ func (s *KeeperTestSuite) TestRemoveAllAndCollect() {
 
 	// Accrue fees.
 	ordererAddr := s.FundedAccount(2, enoughCoins)
-	s.PlaceMarketOrder(market.Id, ordererAddr, true, sdk.NewDec(10_000000))
+	s.PlaceLimitOrder(market.Id, ordererAddr, true, utils.ParseDec("6"), sdk.NewDec(10_000000), 0)
 	s.PlaceMarketOrder(market.Id, ordererAddr, false, sdk.NewDec(10_000000))
 
 	s.RemoveLiquidity(lpAddr, position.Id, position.Liquidity)
@@ -97,8 +97,8 @@ func (s *KeeperTestSuite) TestRewardsPool() {
 		lpAddr, pool2.Id, utils.ParseDec("9"), utils.ParseDec("12"), utils.ParseCoins("100_000000uatom,1000_000000uusd"))
 
 	ordererAddr := s.FundedAccount(2, enoughCoins)
-	s.PlaceMarketOrder(market1.Id, ordererAddr, true, sdk.NewDec(1_000000))
-	s.PlaceMarketOrder(market2.Id, ordererAddr, false, sdk.NewDec(1_000000))
+	s.PlaceLimitOrder(market1.Id, ordererAddr, true, utils.ParseDec("6"), sdk.NewDec(1_000000),0 )
+	s.PlaceLimitOrder(market2.Id, ordererAddr, false, utils.ParseDec("9"), sdk.NewDec(1_000000), 0)
 
 	s.AssertEqual(utils.ParseCoins("1499ucre,2620uusd"), s.GetAllBalances(pool1.MustGetRewardsPoolAddress()))
 	s.AssertEqual(utils.ParseCoins("268uatom,14982uusd"), s.GetAllBalances(pool2.MustGetRewardsPoolAddress()))

--- a/x/amm/keeper/sim_test.go
+++ b/x/amm/keeper/sim_test.go
@@ -28,6 +28,10 @@ func (s *KeeperTestSuite) TestSimulation() {
 			initialPrice = utils.RandomDec(r, utils.ParseDec("100000"), maxPrice)
 		}
 		market, pool := s.CreateMarketAndPool("ucre", "uusd", initialPrice)
+		marketState := s.App.ExchangeKeeper.MustGetMarketState(s.Ctx, market.Id)
+		lastPrice := exchangetypes.PriceAtTick(exchangetypes.TickAtPrice(initialPrice))
+		marketState.LastPrice = &lastPrice
+		s.App.ExchangeKeeper.SetMarketState(s.Ctx, market.Id, marketState)
 
 		lpAddrs := make([]sdk.AccAddress, 10)
 		for i := range lpAddrs {

--- a/x/exchange/keeper/order_test.go
+++ b/x/exchange/keeper/order_test.go
@@ -112,7 +112,8 @@ func (s *KeeperTestSuite) TestPlaceMMLimitOrder() {
 		s.Ctx, market.Id, ordererAddr1, true, utils.ParseDec("5.1"), sdk.NewDec(10_00000), time.Hour)
 	s.Require().EqualError(err, "16 > 15: number of MM orders exceeded the limit")
 
-	s.PlaceMarketOrder(market.Id, ordererAddr2, false, sdk.NewDec(30_000000))
+	s.PlaceLimitOrder(
+		market.Id, ordererAddr2, false, utils.ParseDec("4.9"), sdk.NewDec(30_000000), 0)
 
 	s.PlaceMMLimitOrder(
 		market.Id, ordererAddr1, true, utils.ParseDec("4.9"), sdk.NewDec(10_00000), time.Hour)
@@ -134,7 +135,8 @@ func (s *KeeperTestSuite) TestPlaceMMBatchLimitOrder() {
 		s.Ctx, market.Id, ordererAddr1, true, utils.ParseDec("5.1"), sdk.NewDec(10_00000), time.Hour)
 	s.Require().EqualError(err, "16 > 15: number of MM orders exceeded the limit")
 
-	s.PlaceMarketOrder(market.Id, ordererAddr2, false, sdk.NewDec(30_000000))
+	s.PlaceLimitOrder(
+		market.Id, ordererAddr2, false, utils.ParseDec("4.9"), sdk.NewDec(30_000000), 0)
 	s.NextBlock()
 
 	s.PlaceMMBatchLimitOrder(
@@ -246,7 +248,8 @@ func (s *KeeperTestSuite) TestFairMatching() {
 	_, order2, _ := s.PlaceLimitOrder(
 		market.Id, ordererAddr2, true, utils.ParseDec("1.2"), sdk.NewDec(5000), 0)
 
-	s.PlaceMarketOrder(market.Id, ordererAddr3, false, sdk.NewDec(9000))
+	s.PlaceLimitOrder(
+		market.Id, ordererAddr3, false, utils.ParseDec("1.1"), sdk.NewDec(9000), 0)
 
 	order1, _ = s.keeper.GetOrder(s.Ctx, order1.Id)
 	order2, _ = s.keeper.GetOrder(s.Ctx, order2.Id)
@@ -257,9 +260,9 @@ func (s *KeeperTestSuite) TestFairMatching() {
 	s.NextBlock()
 
 	_, order1, _ = s.PlaceLimitOrder(
-		market.Id, ordererAddr1, true, utils.ParseDec("0.3"), sdk.NewDec(7000), 0)
+		market.Id, ordererAddr1, true, utils.ParseDec("1.1"), sdk.NewDec(7000), 0)
 	_, order2, _ = s.PlaceLimitOrder(
-		market.Id, ordererAddr2, true, utils.ParseDec("0.3"), sdk.NewDec(3000), 0)
+		market.Id, ordererAddr2, true, utils.ParseDec("1.1"), sdk.NewDec(3000), 0)
 
 	s.PlaceMarketOrder(market.Id, ordererAddr3, false, sdk.NewDec(101))
 
@@ -286,7 +289,8 @@ func (s *KeeperTestSuite) TestDecQuantity() {
 	_, order2, _ := s.PlaceLimitOrder(
 		market.Id, ordererAddr2, true, utils.ParseDec("0.14076"), sdk.NewDec(3000), time.Hour)
 
-	s.PlaceMarketOrder(market.Id, ordererAddr3, false, sdk.NewDec(1001))
+	s.PlaceLimitOrder(
+		market.Id, ordererAddr3, false, utils.ParseDec("0.14"), sdk.NewDec(1001), 0)
 
 	order1, _ = s.keeper.GetOrder(s.Ctx, order1.Id)
 	order2, _ = s.keeper.GetOrder(s.Ctx, order2.Id)

--- a/x/exchange/simulation/operations.go
+++ b/x/exchange/simulation/operations.go
@@ -439,6 +439,10 @@ func findMsgPlaceMarketOrderParams(
 	accs = utils.ShuffleSimAccounts(r, accs)
 	var markets []types.Market
 	k.IterateAllMarkets(ctx, func(market types.Market) (stop bool) {
+		marketState := k.MustGetMarketState(ctx, market.Id)
+		if marketState.LastPrice == nil { // skip markets with no last price
+			return false
+		}
 		markets = append(markets, market)
 		return false
 	})

--- a/x/exchange/simulation/operations_test.go
+++ b/x/exchange/simulation/operations_test.go
@@ -129,7 +129,10 @@ func (s *SimTestSuite) TestSimulateMsgPlaceMarketOrder() {
 	r := rand.New(rand.NewSource(0))
 	accs := s.getTestingAccounts(r, 50)
 
-	s.CreateMarket("denom1", "denom2")
+	market := s.CreateMarket("denom1", "denom2")
+	marketState := s.keeper.MustGetMarketState(s.Ctx, market.Id)
+	marketState.LastPrice = utils.ParseDecP("1.2")
+	s.keeper.SetMarketState(s.Ctx, market.Id, marketState)
 
 	op := simulation.SimulateMsgPlaceMarketOrder(
 		s.App.AccountKeeper, s.App.BankKeeper, s.keeper)


### PR DESCRIPTION
## Description

This PR applies `MaxOrderPriceRatio` limit to market orders.