### PR TITLE
fix: update x/liquidstaking to use new modules

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -532,18 +532,6 @@ func NewApp(
 		app.BankKeeper,
 		app.LiquidityKeeper,
 	)
-	app.LiquidStakingKeeper = liquidstakingkeeper.NewKeeper(
-		appCodec,
-		keys[liquidstakingtypes.StoreKey],
-		app.GetSubspace(liquidstakingtypes.ModuleName),
-		app.AccountKeeper,
-		app.BankKeeper,
-		app.StakingKeeper,
-		app.DistrKeeper,
-		app.LiquidityKeeper,
-		app.LPFarmKeeper,
-		app.SlashingKeeper,
-	)
 	app.ExchangeKeeper = exchangekeeper.NewKeeper(
 		appCodec,
 		keys[exchangetypes.StoreKey],
@@ -583,6 +571,19 @@ func NewApp(
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.AMMKeeper,
+	)
+	app.LiquidStakingKeeper = liquidstakingkeeper.NewKeeper(
+		appCodec,
+		keys[liquidstakingtypes.StoreKey],
+		app.GetSubspace(liquidstakingtypes.ModuleName),
+		app.AccountKeeper,
+		app.BankKeeper,
+		app.StakingKeeper,
+		app.DistrKeeper,
+		app.AMMKeeper,
+		app.LiquidAMMKeeper,
+		app.LPFarmKeeper,
+		app.SlashingKeeper,
 	)
 
 	// register the proposal types

--- a/types/utils.go
+++ b/types/utils.go
@@ -126,6 +126,9 @@ func DecApproxEqual(a, b sdk.Dec) bool {
 	if b.GT(a) {
 		a, b = b, a
 	}
+	if a.IsZero() && b.IsZero() {
+		return true
+	}
 	return a.Sub(b).Quo(a).LTE(sdk.NewDecWithPrec(1, 3))
 }
 

--- a/x/liquidstaking/keeper/keeper.go
+++ b/x/liquidstaking/keeper/keeper.go
@@ -21,7 +21,8 @@ type Keeper struct {
 	bankKeeper      types.BankKeeper
 	stakingKeeper   types.StakingKeeper
 	distrKeeper     types.DistrKeeper
-	liquidityKeeper types.LiquidityKeeper
+	ammKeeper       types.AMMKeeper
+	liquidAMMKeeper types.LiquidAMMKeeper
 	lpfarmKeeper    types.LPFarmKeeper
 	slashingKeeper  types.SlashingKeeper
 }
@@ -32,7 +33,7 @@ type Keeper struct {
 // - minting, burning PoolCoins
 func NewKeeper(cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
 	accountKeeper types.AccountKeeper, bankKeeper types.BankKeeper, stakingKeeper types.StakingKeeper,
-	distrKeeper types.DistrKeeper, liquidityKeeper types.LiquidityKeeper,
+	distrKeeper types.DistrKeeper, ammKeeper types.AMMKeeper, liquidAMMKeeper types.LiquidAMMKeeper,
 	lpfarmKeeper types.LPFarmKeeper, slashingKeeper types.SlashingKeeper,
 ) Keeper {
 	// ensure liquidstaking module account is set
@@ -53,7 +54,8 @@ func NewKeeper(cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Su
 		bankKeeper:      bankKeeper,
 		stakingKeeper:   stakingKeeper,
 		distrKeeper:     distrKeeper,
-		liquidityKeeper: liquidityKeeper,
+		ammKeeper:       ammKeeper,
+		liquidAMMKeeper: liquidAMMKeeper,
 		lpfarmKeeper:    lpfarmKeeper,
 		slashingKeeper:  slashingKeeper,
 	}

--- a/x/liquidstaking/keeper/keeper_test.go
+++ b/x/liquidstaking/keeper/keeper_test.go
@@ -23,12 +23,15 @@ import (
 
 	chain "github.com/crescent-network/crescent/v5/app"
 	utils "github.com/crescent-network/crescent/v5/types"
-	liquiditytypes "github.com/crescent-network/crescent/v5/x/liquidity/types"
+	ammtypes "github.com/crescent-network/crescent/v5/x/amm/types"
+	exchangetypes "github.com/crescent-network/crescent/v5/x/exchange/types"
+	liquidammtypes "github.com/crescent-network/crescent/v5/x/liquidamm/types"
 	"github.com/crescent-network/crescent/v5/x/liquidstaking"
 	"github.com/crescent-network/crescent/v5/x/liquidstaking/keeper"
 	"github.com/crescent-network/crescent/v5/x/liquidstaking/types"
 	lpfarmtypes "github.com/crescent-network/crescent/v5/x/lpfarm/types"
 	"github.com/crescent-network/crescent/v5/x/mint"
+	minttypes "github.com/crescent-network/crescent/v5/x/mint/types"
 )
 
 var (
@@ -335,32 +338,49 @@ func (s *KeeperTestSuite) createContinuousVestingAccount(from sdk.AccAddress, to
 }
 
 func (s *KeeperTestSuite) fundAddr(addr sdk.AccAddress, amt sdk.Coins) {
-	err := s.app.BankKeeper.MintCoins(s.ctx, liquiditytypes.ModuleName, amt)
+	err := s.app.BankKeeper.MintCoins(s.ctx, minttypes.ModuleName, amt)
 	s.Require().NoError(err)
-	err = s.app.BankKeeper.SendCoinsFromModuleToAccount(s.ctx, liquiditytypes.ModuleName, addr, amt)
+	err = s.app.BankKeeper.SendCoinsFromModuleToAccount(s.ctx, minttypes.ModuleName, addr, amt)
 	s.Require().NoError(err)
 }
 
-// liquidity module keeper utils for liquid staking combine test
-
-func (s *KeeperTestSuite) createPair(creator sdk.AccAddress, baseCoinDenom, quoteCoinDenom string, fund bool) liquiditytypes.Pair {
-	params := s.app.LiquidityKeeper.GetParams(s.ctx)
-	if fund {
-		s.fundAddr(creator, params.PairCreationFee)
-	}
-	pair, err := s.app.LiquidityKeeper.CreatePair(s.ctx, liquiditytypes.NewMsgCreatePair(creator, baseCoinDenom, quoteCoinDenom))
+func (s *KeeperTestSuite) createMarketAndPool(baseDenom, quoteDenom string, price sdk.Dec) (market exchangetypes.Market, pool ammtypes.Pool) {
+	s.T().Helper()
+	creatorAddr := utils.TestAddress(100000)
+	s.fundAddr(creatorAddr, s.app.ExchangeKeeper.GetMarketCreationFee(s.ctx))
+	var err error
+	market, err = s.app.ExchangeKeeper.CreateMarket(s.ctx, creatorAddr, baseDenom, quoteDenom)
 	s.Require().NoError(err)
-	return pair
+	s.fundAddr(creatorAddr, s.app.AMMKeeper.GetPoolCreationFee(s.ctx))
+	pool, err = s.app.AMMKeeper.CreatePool(s.ctx, creatorAddr, market.Id, price)
+	s.Require().NoError(err)
+	return
 }
 
-func (s *KeeperTestSuite) createPool(creator sdk.AccAddress, pairId uint64, depositCoins sdk.Coins, fund bool) liquiditytypes.Pool {
-	params := s.app.LiquidityKeeper.GetParams(s.ctx)
-	if fund {
-		s.fundAddr(creator, depositCoins.Add(params.PoolCreationFee...))
-	}
-	pool, err := s.app.LiquidityKeeper.CreatePool(s.ctx, liquiditytypes.NewMsgCreatePool(creator, pairId, depositCoins))
+func (s *KeeperTestSuite) addLiquidity(
+	ownerAddr sdk.AccAddress, poolId uint64, lowerPrice, upperPrice sdk.Dec, desiredAmt sdk.Coins) (position ammtypes.Position, liquidity sdk.Int, amt sdk.Coins) {
+	s.T().Helper()
+	var err error
+	position, liquidity, amt, err = s.app.AMMKeeper.AddLiquidity(s.ctx, ownerAddr, ownerAddr, poolId, lowerPrice, upperPrice, desiredAmt)
 	s.Require().NoError(err)
-	return pool
+	return
+}
+
+func (s *KeeperTestSuite) createPublicPosition(
+	poolId uint64, lowerPrice, upperPrice sdk.Dec, minBidAmt sdk.Int, feeRate sdk.Dec) liquidammtypes.PublicPosition {
+	s.T().Helper()
+	publicPosition, err := s.app.LiquidAMMKeeper.CreatePublicPosition(s.ctx, poolId, lowerPrice, upperPrice, minBidAmt, feeRate)
+	s.Require().NoError(err)
+	return publicPosition
+}
+
+func (s *KeeperTestSuite) mintShare(
+	senderAddr sdk.AccAddress, publicPositionId uint64, desiredAmt sdk.Coins) (mintedShare sdk.Coin, position ammtypes.Position, liquidity sdk.Int, amt sdk.Coins) {
+	s.T().Helper()
+	var err error
+	mintedShare, position, liquidity, amt, err = s.app.LiquidAMMKeeper.MintShare(s.ctx, senderAddr, publicPositionId, desiredAmt)
+	s.Require().NoError(err)
+	return
 }
 
 // farming module keeper utils for liquid staking combine test
@@ -383,13 +403,13 @@ func (s *KeeperTestSuite) farm(farmerAddr sdk.AccAddress, coin sdk.Coin) {
 	s.Require().NoError(err)
 }
 
-func (s *KeeperTestSuite) assertTallyResult(yes, no, vito, abstain int64, proposal govtypes.Proposal) {
+func (s *KeeperTestSuite) assertTallyResult(yes, no, veto, abstain int64, proposal govtypes.Proposal) {
 	cachedCtx, _ := s.ctx.CacheContext()
 	_, _, result := s.app.GovKeeper.Tally(cachedCtx, proposal)
-	s.Require().Equal(sdk.NewInt(yes), result.Yes)
-	s.Require().Equal(sdk.NewInt(no), result.No)
-	s.Require().Equal(sdk.NewInt(vito), result.NoWithVeto)
-	s.Require().Equal(sdk.NewInt(abstain), result.Abstain)
+	s.Require().True(utils.DecApproxEqual(sdk.NewDec(yes), result.Yes.ToDec()))
+	s.Require().True(utils.DecApproxEqual(sdk.NewDec(no), result.No.ToDec()))
+	s.Require().True(utils.DecApproxEqual(sdk.NewDec(veto), result.NoWithVeto.ToDec()))
+	s.Require().True(utils.DecApproxEqual(sdk.NewDec(abstain), result.Abstain.ToDec()))
 }
 
 func (s *KeeperTestSuite) assertVotingPower(addr sdk.AccAddress, stakingVotingPower, liquidStakingVotingPower, validatorVotingPower sdk.Int) {

--- a/x/liquidstaking/keeper/tally.go
+++ b/x/liquidstaking/keeper/tally.go
@@ -73,7 +73,11 @@ func (k Keeper) GetBTokenSharePerPublicPositionShareMap(ctx sdk.Context, targetD
 func (k Keeper) BTokenSharePerPublicPositionShare(ctx sdk.Context, publicPosition liquidammtypes.PublicPosition, targetDenom string) sdk.Dec {
 	shareDenom := liquidammtypes.ShareDenom(publicPosition.Id)
 
-	ammPosition := k.liquidAMMKeeper.MustGetAMMPosition(ctx, publicPosition)
+	ammPosition, found := k.liquidAMMKeeper.GetAMMPosition(ctx, publicPosition)
+	if !found {
+		// The public position is not initialized(gained liquidity) yet.
+		return utils.ZeroDec
+	}
 	coin0, coin1, err := k.ammKeeper.PositionAssets(ctx, ammPosition.Id)
 	if err != nil {
 		// TODO: panic instead?

--- a/x/liquidstaking/spec/01_concepts.md
+++ b/x/liquidstaking/spec/01_concepts.md
@@ -15,9 +15,9 @@ Liquid validators are determined through governance process. They must be define
 The module acknowledges voting power of all voters by aggregating the core activities that is related to the bToken. These are the following core activities:
 
 - Balance of `bToken`
-- Balance of `PoolCoin(s)` that includes `bToken`
+- Balance of amm positions that includes `bToken`
 - Farming position of `bToken`
-- Farming position of `PoolCoin(s)` that include `bToken`
+- Farming position of public positions that include `bToken`
 
 ## Rebalancing
 

--- a/x/liquidstaking/spec/06_hooks.md
+++ b/x/liquidstaking/spec/06_hooks.md
@@ -11,7 +11,7 @@ SetAdditionalVotingPowers calculates the voter's voting power who owns `bToken` 
 - Farming position of bToken
 - Farming position of PoolCoins that include bToken
 
-The calculation is dependent on `x/liquidity` and `x/farming` modules and the farming position considers both staking and queued staking amounts.
+The calculation is dependent on `x/amm`, `x/liquidamm` and `x/lpfarm` modules.
 
 The calculated voting power is added, deducted, or overwritten with `AdditionalVotingPowers` inside the tally logic of `cosmos-sdk/x/gov` module. It is called in `govHooks.SetAdditionalVotingPowers`. 
 

--- a/x/liquidstaking/types/expected_keepers.go
+++ b/x/liquidstaking/types/expected_keepers.go
@@ -9,7 +9,8 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	liquiditytypes "github.com/crescent-network/crescent/v5/x/liquidity/types"
+	ammtypes "github.com/crescent-network/crescent/v5/x/amm/types"
+	liquidammtypes "github.com/crescent-network/crescent/v5/x/liquidamm/types"
 	lpfarmtypes "github.com/crescent-network/crescent/v5/x/lpfarm/types"
 )
 
@@ -98,13 +99,14 @@ type DistrKeeper interface {
 	WithdrawDelegationRewards(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (sdk.Coins, error)
 }
 
-// Liquidity expected liquidity keeper (noalias)
-type LiquidityKeeper interface {
-	GetPair(ctx sdk.Context, id uint64) (pair liquiditytypes.Pair, found bool)
-	GetPool(ctx sdk.Context, id uint64) (pool liquiditytypes.Pool, found bool)
-	GetPoolBalances(ctx sdk.Context, pool liquiditytypes.Pool) (rx sdk.Coin, ry sdk.Coin)
-	GetPoolCoinSupply(ctx sdk.Context, pool liquiditytypes.Pool) sdk.Int
-	IterateAllPools(ctx sdk.Context, cb func(pool liquiditytypes.Pool) (stop bool, err error)) error
+type AMMKeeper interface {
+	IteratePositionsByOwner(ctx sdk.Context, ownerAddr sdk.AccAddress, cb func(position ammtypes.Position) (stop bool))
+	PositionAssets(ctx sdk.Context, positionId uint64) (coin0, coin1 sdk.Coin, err error)
+}
+
+type LiquidAMMKeeper interface {
+	IterateAllPublicPositions(ctx sdk.Context, cb func(publicPosition liquidammtypes.PublicPosition) (stop bool))
+	MustGetAMMPosition(ctx sdk.Context, publicPosition liquidammtypes.PublicPosition) ammtypes.Position
 }
 
 // LPFarmKeeper defines expected lpfarm keeper

--- a/x/liquidstaking/types/expected_keepers.go
+++ b/x/liquidstaking/types/expected_keepers.go
@@ -106,7 +106,7 @@ type AMMKeeper interface {
 
 type LiquidAMMKeeper interface {
 	IterateAllPublicPositions(ctx sdk.Context, cb func(publicPosition liquidammtypes.PublicPosition) (stop bool))
-	MustGetAMMPosition(ctx sdk.Context, publicPosition liquidammtypes.PublicPosition) ammtypes.Position
+	GetAMMPosition(ctx sdk.Context, publicPosition liquidammtypes.PublicPosition) (position ammtypes.Position, found bool)
 }
 
 // LPFarmKeeper defines expected lpfarm keeper


### PR DESCRIPTION
## Description

This PR updates x/liquidstaking to use new modules(x/amm, x/liquidamm) instead of deprecated x/liquidity.