### PR TITLE
fix: force paid/received/deposit to be integers for user orders

### DIFF
--- a/x/exchange/keeper/invariants.go
+++ b/x/exchange/keeper/invariants.go
@@ -75,6 +75,11 @@ func OrderStateInvariant(k Keeper) sdk.Invariant {
 				msg += fmt.Sprintf("\torder %d should have been deleted since it has no executable quantity\n", order.Id)
 				cnt++
 			}
+			if !order.RemainingDeposit.TruncateDec().Equal(order.RemainingDeposit) {
+				msg += fmt.Sprintf("\torder %d should have integer remaining deposit but has %s\n",
+					order.Id, order.RemainingDeposit)
+				cnt++
+			}
 			return false
 		})
 		broken := cnt != 0

--- a/x/exchange/keeper/order_test.go
+++ b/x/exchange/keeper/order_test.go
@@ -306,8 +306,11 @@ func (s *KeeperTestSuite) TestDecQuantity() {
 	s.PlaceMarketOrder(market.Id, ordererAddr3, false, sdk.NewDec(10000))
 	orderer3BalancesAfter := s.GetAllBalances(ordererAddr3)
 
+	// order2 remaining deposit = 380uusd
+	// order2 executable quantity ~= 2699.6305768
+	// order2 executable quantity * 0.14076 ~= 379.9999999
 	diff, _ := orderer3BalancesAfter.SafeSub(orderer3BalancesBefore)
-	s.AssertEqual(sdk.NewInt(380), diff.AmountOf("uusd")) // 2699.7*0.14076=380.009722
+	s.AssertEqual(sdk.NewInt(379), diff.AmountOf("uusd"))
 }
 
 func (s *KeeperTestSuite) TestNumMMOrdersEdgecase() {

--- a/x/exchange/types/mem_order.go
+++ b/x/exchange/types/mem_order.go
@@ -159,7 +159,7 @@ func (order *MemOrder) ExecutableQuantity() sdk.Dec {
 	if order.isBuy {
 		return sdk.MinDec(executableQty, order.remainingDeposit.QuoTruncate(order.price))
 	}
-	return executableQty
+	return sdk.MinDec(executableQty, order.remainingDeposit)
 }
 
 func (order *MemOrder) HasPriorityOver(other *MemOrder) bool {


### PR DESCRIPTION
## Description

Force `Paid`/`Received`/`RemainingDeposit` to all be integers for user orders. This would conservatively prevent some unknown edge cases.