### PR TITLE
fix: fix bug in PositionAssets when position liquidity is zero

### DIFF
--- a/x/amm/keeper/position.go
+++ b/x/amm/keeper/position.go
@@ -190,6 +190,11 @@ func (k Keeper) PositionAssets(ctx sdk.Context, positionId uint64) (coin0, coin1
 		return coin0, coin1, sdkerrors.Wrap(sdkerrors.ErrNotFound, "position not found")
 	}
 	pool := k.MustGetPool(ctx, position.PoolId)
+	if position.Liquidity.IsZero() {
+		coin0 = sdk.NewInt64Coin(pool.Denom0, 0)
+		coin1 = sdk.NewInt64Coin(pool.Denom1, 0)
+		return
+	}
 	ctx, _ = ctx.CacheContext()
 	_, amt0, amt1 := k.modifyPosition(
 		ctx, pool, position.MustGetOwnerAddress(), position.LowerTick, position.UpperTick, position.Liquidity.Neg())

--- a/x/liquidstaking/keeper/keeper_test.go
+++ b/x/liquidstaking/keeper/keeper_test.go
@@ -366,6 +366,15 @@ func (s *KeeperTestSuite) addLiquidity(
 	return
 }
 
+func (s *KeeperTestSuite) removeLiquidity(
+	ownerAddr sdk.AccAddress, positionId uint64, liquidity sdk.Int) (position ammtypes.Position, amt sdk.Coins) {
+	s.T().Helper()
+	var err error
+	position, amt, err = s.app.AMMKeeper.RemoveLiquidity(s.ctx, ownerAddr, ownerAddr, positionId, liquidity)
+	s.Require().NoError(err)
+	return
+}
+
 func (s *KeeperTestSuite) createPublicPosition(
 	poolId uint64, lowerPrice, upperPrice sdk.Dec, minBidAmt sdk.Int, feeRate sdk.Dec) liquidammtypes.PublicPosition {
 	s.T().Helper()

--- a/x/liquidstaking/keeper/tally_test.go
+++ b/x/liquidstaking/keeper/tally_test.go
@@ -569,7 +569,7 @@ func (s *KeeperTestSuite) TestCalcLiquidStakingVotingPower() {
 	s.Require().Equal(sdk.NewInt(200_000000), s.keeper.CalcLiquidStakingVotingPower(s.ctx, delB))
 
 	_, pool := s.createMarketAndPool(params.LiquidBondDenom, sdk.DefaultBondDenom, utils.ParseDec("1"))
-	s.addLiquidity(
+	position1, _, _ := s.addLiquidity(
 		delA, pool.Id, utils.ParseDec("1"), utils.ParseDec("1.2"),
 		sdk.NewCoins(
 			sdk.NewInt64Coin(params.LiquidBondDenom, 10_000000),
@@ -607,6 +607,12 @@ func (s *KeeperTestSuite) TestCalcLiquidStakingVotingPower() {
 			sdk.NewInt64Coin(params.LiquidBondDenom, 20_000000),
 			sdk.NewInt64Coin(sdk.DefaultBondDenom, 20_000000)))
 	// There might be a small amount of error again.
+	s.Require().Equal(sdk.NewInt(99_999998), s.keeper.CalcLiquidStakingVotingPower(s.ctx, delA))
+	s.Require().Equal(sdk.NewInt(199_999998), s.keeper.CalcLiquidStakingVotingPower(s.ctx, delB))
+
+	// Remove all liquidity
+	s.removeLiquidity(delA, position1.Id, position1.Liquidity)
+
 	s.Require().Equal(sdk.NewInt(99_999998), s.keeper.CalcLiquidStakingVotingPower(s.ctx, delA))
 	s.Require().Equal(sdk.NewInt(199_999998), s.keeper.CalcLiquidStakingVotingPower(s.ctx, delB))
 }


### PR DESCRIPTION
## Description

This PR fixes a bug in `PositionAssets`, which causes panic in tally logic when the voter has zero liquidity positions. Note: If someone removes all liquidity in a position, the position is not deleted and remaining as zero liquidity positions.