### PR TITLE
fix: set public position indexes in InitGenesis and fix minor issues

### DIFF
--- a/x/amm/keeper/farming.go
+++ b/x/amm/keeper/farming.go
@@ -23,8 +23,10 @@ func (k Keeper) CreatePrivateFarmingPlan(
 			"maximum number of active private farming plans reached")
 	}
 	fee := k.GetPrivateFarmingPlanCreationFee(ctx)
-	if err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, creatorAddr, types.ModuleName, fee); err != nil {
-		return
+	if fee.IsAllPositive() {
+		if err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, creatorAddr, types.ModuleName, fee); err != nil {
+			return
+		}
 	}
 	plan, err = k.createFarmingPlan(ctx, description, nil, termAddr, rewardAllocs, startTime, endTime, true)
 	if err != nil {

--- a/x/amm/keeper/pool.go
+++ b/x/amm/keeper/pool.go
@@ -21,9 +21,11 @@ func (k Keeper) CreatePool(ctx sdk.Context, creatorAddr sdk.AccAddress, marketId
 	}
 
 	creationFee := k.GetPoolCreationFee(ctx)
-	if err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, creatorAddr, types.ModuleName, creationFee); err != nil {
-		err = sdkerrors.Wrap(err, "insufficient pool creation fee")
-		return
+	if creationFee.IsAllPositive() {
+		if err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, creatorAddr, types.ModuleName, creationFee); err != nil {
+			err = sdkerrors.Wrap(err, "insufficient pool creation fee")
+			return
+		}
 	}
 
 	// Create a new pool

--- a/x/amm/keeper/source.go
+++ b/x/amm/keeper/source.go
@@ -226,9 +226,11 @@ func (k Keeper) AfterPoolOrdersExecuted(ctx sdk.Context, pool types.Pool, result
 	accrueFees()
 	k.SetPoolState(ctx, pool.Id, poolState)
 
-	if err := k.bankKeeper.SendCoins(
-		ctx, reserveAddr, pool.MustGetRewardsPoolAddress(), accruedRewards); err != nil {
-		return err
+	if accruedRewards.IsAllPositive() {
+		if err := k.bankKeeper.SendCoins(
+			ctx, reserveAddr, pool.MustGetRewardsPoolAddress(), accruedRewards); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/x/liquidamm/keeper/genesis.go
+++ b/x/liquidamm/keeper/genesis.go
@@ -16,6 +16,8 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 	}
 	for _, publicPosition := range genState.PublicPositions {
 		k.SetPublicPosition(ctx, publicPosition)
+		k.SetPublicPositionByParamsIndex(ctx, publicPosition)
+		k.SetPublicPositionsByPoolIndex(ctx, publicPosition)
 	}
 	for _, auction := range genState.RewardsAuctions {
 		k.SetRewardsAuction(ctx, auction)


### PR DESCRIPTION
## Description

This PR fixes missing `Set~Index` calls in x/liquidamm's `InitGenesis`. Also, check if amount is all positive when calling `BankKeeper.SendCoins`.